### PR TITLE
Expand universe and add summary report

### DIFF
--- a/data/reference/ticker_names.yaml
+++ b/data/reference/ticker_names.yaml
@@ -14,3 +14,7 @@
 8058.T: Mitsubishi Corporation
 8591.T: ORIX Corporation
 8267.T: Aeon Co., Ltd.
+3382.T: Seven & i Holdings Co., Ltd.
+6301.T: Komatsu Ltd.
+4502.T: Takeda Pharmaceutical Company Limited
+9433.T: KDDI Corporation

--- a/reports/portfolio/summary.yaml
+++ b/reports/portfolio/summary.yaml
@@ -1,0 +1,41 @@
+years:
+  2013:
+    annual_return: 0.702440
+    volatility: 0.267459
+    sharpe_ratio: 2.626344
+    max_drawdown: -0.150676
+  2014:
+    annual_return: 0.348172
+    volatility: 0.209475
+    sharpe_ratio: 1.662119
+    max_drawdown: -0.112138
+  2015:
+    annual_return: 0.272795
+    volatility: 0.245335
+    sharpe_ratio: 1.111932
+    max_drawdown: -0.256841
+  2016:
+    annual_return: 0.373497
+    volatility: 0.287424
+    sharpe_ratio: 1.299462
+    max_drawdown: -0.187595
+  2017:
+    annual_return: 0.354970
+    volatility: 0.150586
+    sharpe_ratio: 2.357250
+    max_drawdown: -0.076803
+  2018:
+    annual_return: -0.049827
+    volatility: 0.203411
+    sharpe_ratio: -0.244956
+    max_drawdown: -0.257289
+  2019:
+    annual_return: 0.399131
+    volatility: 0.153784
+    sharpe_ratio: 2.595390
+    max_drawdown: -0.082407
+  2020:
+    annual_return: 0.462244
+    volatility: 0.308375
+    sharpe_ratio: 1.498969
+    max_drawdown: -0.345097

--- a/src/common/universe.py
+++ b/src/common/universe.py
@@ -15,6 +15,10 @@ TICKERS = [
     "8058.T",
     "8591.T",
     "8267.T",
+    "3382.T",
+    "6301.T",
+    "4502.T",
+    "9433.T",
 ]
 CLASSIFICATION = {
     "7203.T": "automobile",
@@ -33,4 +37,8 @@ CLASSIFICATION = {
     "8058.T": "trading",
     "8591.T": "leasing",
     "8267.T": "consumer_retail",
+    "3382.T": "consumer_retail",
+    "6301.T": "industrial",
+    "4502.T": "pharmaceutical",
+    "9433.T": "telecom",
 }

--- a/src/reporting/yaml_reporter.py
+++ b/src/reporting/yaml_reporter.py
@@ -42,7 +42,12 @@ def _yaml_lines(data, indent=0):
 
 def write_reports(results, directory):
     directory.mkdir(parents=True, exist_ok=True)
+    summary = {}
     for year, payload in results.items():
         rounded = _round_numbers(payload)
         lines = _yaml_lines(rounded)
         (directory / f"{year}.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        summary[str(year)] = rounded["portfolio"]["risk_metrics"]
+    if summary:
+        lines = _yaml_lines({"years": summary})
+        (directory / "summary.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add four additional tickers with classification metadata and display names
- generate a static summary YAML alongside yearly reports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4ae6502888325a4d6b1d37f35151a