### PR TITLE
Refactor reporting helpers to reduce duplication

### DIFF
--- a/src/reporting/yaml_reporter.py
+++ b/src/reporting/yaml_reporter.py
@@ -1,53 +1,30 @@
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
+import yaml
 
-def _round_numbers(data):
+
+def _map_nested(data, transform):
     if isinstance(data, float):
-        return round(data, 6)
-    if isinstance(data, dict):
-        return {key: _round_numbers(value) for key, value in data.items()}
-    if isinstance(data, list):
-        return [_round_numbers(value) for value in data]
+        return transform(data)
+    if isinstance(data, Mapping):
+        return {key: _map_nested(value, transform) for key, value in data.items()}
+    if isinstance(data, Sequence) and not isinstance(data, (str, bytes)):
+        return [_map_nested(value, transform) for value in data]
     return data
 
 
-def _scalar(value):
-    if isinstance(value, float):
-        return f"{value:.6f}"
-    return str(value)
-
-
-def _yaml_lines(data, indent=0):
-    prefix = "  " * indent
-    if isinstance(data, dict):
-        lines = []
-        for key, value in data.items():
-            if isinstance(value, (dict, list)):
-                lines.append(f"{prefix}{key}:")
-                lines.extend(_yaml_lines(value, indent + 1))
-            else:
-                lines.append(f"{prefix}{key}: {_scalar(value)}")
-        return lines
-    if isinstance(data, list):
-        lines = []
-        for value in data:
-            if isinstance(value, (dict, list)):
-                lines.append(f"{prefix}-")
-                lines.extend(_yaml_lines(value, indent + 1))
-            else:
-                lines.append(f"{prefix}- {_scalar(value)}")
-        return lines
-    return [f"{prefix}{_scalar(data)}"]
+def _dump_yaml(data):
+    formatted = _map_nested(data, lambda value: f"{value:.6f}")
+    return yaml.safe_dump(formatted, sort_keys=False, allow_unicode=True)
 
 
 def write_reports(results, directory):
     directory.mkdir(parents=True, exist_ok=True)
     summary = {}
     for year, payload in results.items():
-        rounded = _round_numbers(payload)
-        lines = _yaml_lines(rounded)
-        (directory / f"{year}.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        rounded = _map_nested(payload, lambda value: round(value, 6))
+        (directory / f"{year}.yaml").write_text(_dump_yaml(rounded), encoding="utf-8")
         summary[str(year)] = rounded["portfolio"]["risk_metrics"]
     if summary:
-        lines = _yaml_lines({"years": summary})
-        (directory / "summary.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        (directory / "summary.yaml").write_text(_dump_yaml({"years": summary}), encoding="utf-8")


### PR DESCRIPTION
## Summary
- replace the hand-written YAML rendering with a reusable nested mapping helper that uses PyYAML for output
- simplify yearly portfolio generation by reusing a precomputed universe and a helper builder to trim redundant code

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e4af9af32c8325b81095e97eaa6967