### PR TITLE
Add static portfolio performance snapshot

### DIFF
--- a/docs/portfolio_static_report.md
+++ b/docs/portfolio_static_report.md
@@ -1,0 +1,40 @@
+# Portfolio Performance Snapshot (2013-2020)
+
+This document distills the contents of `reports/portfolio/summary.yaml` into the essentials investors care about: how much the portfolio earned, how consistently it did so, and the scale of losses along the way.
+
+## Headline Metrics
+
+| Metric | Figure |
+| --- | --- |
+| Average annual return | 35.8% |
+| Median annual return | 36.4% |
+| Best year (return) | 2013 · 70.2% |
+| Toughest year (return) | 2018 · -5.0% |
+| Highest Sharpe ratio | 2013 · 2.63 |
+| Lowest Sharpe ratio | 2018 · -0.24 |
+| Largest drawdown | 2020 · -34.5% |
+| Calmest year (volatility) | 2017 · 15.1% |
+| Choppier year (volatility) | 2020 · 30.8% |
+
+> **Read this first:** The strategy has delivered strong gains overall, but the trade-off is meaningful drawdowns in crisis periods (e.g., 2020). Pair the headline numbers with the drawdown profile before assuming similar comfort going forward.
+
+## Year-by-Year View
+
+| Year | Return | Volatility | Sharpe | Max Drawdown | Takeaway |
+| --- | --- | --- | --- | --- | --- |
+| 2013 | 70.2% | 26.7% | 2.63 | -15.1% | Breakout year that sets the long-term average. |
+| 2014 | 34.8% | 21.0% | 1.66 | -11.2% | Solid compounding with manageable risk. |
+| 2015 | 27.3% | 24.5% | 1.11 | -25.7% | Gains persisted, but drawdowns deepened. |
+| 2016 | 37.3% | 28.7% | 1.30 | -18.8% | Volatility rises alongside strong performance. |
+| 2017 | 35.5% | 15.1% | 2.36 | -7.7% | Stand-out risk-adjusted year; unusually calm. |
+| 2018 | -5.0% | 20.3% | -0.24 | -25.7% | Only losing year; stress-test for risk tolerance. |
+| 2019 | 39.9% | 15.4% | 2.60 | -8.2% | Quick rebound with efficient risk usage. |
+| 2020 | 46.2% | 30.8% | 1.50 | -34.5% | High return but the largest drawdown in the sample. |
+
+## How to Use This Snapshot
+
+1. **Set expectations** – Use the average and median returns as a base case, but budget for at least a -35% peak-to-trough hit.
+2. **Assess consistency** – Prioritize the Sharpe ratio trend when comparing to alternatives; 2013 and 2019 show the attainable upper bound.
+3. **Plan for stress** – 2018 and 2020 offer realistic worst-case scenarios for losses and volatility spikes. Ensure capital allocation can withstand them.
+
+For additional context on policy backdrops, refer to `docs/abenomics_overview.md`.


### PR DESCRIPTION
## Summary
- add a concise Markdown report that summarizes the portfolio metrics stored in reports/portfolio/summary.yaml
- highlight headline averages, best and worst years, and a year-by-year view with takeaways
- provide guidance on how to interpret the metrics for expectation-setting and risk planning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4b0be65a48325b7775a529f5050a2