### PR TITLE
Add top holdings section to summary report

### DIFF
--- a/reports/portfolio/summary_report.md
+++ b/reports/portfolio/summary_report.md
@@ -30,3 +30,16 @@
 - リスク許容度を確認し、2018年の下落幅-29.8%を想定したドローダウン管理を整備しましょう。
 - 安定性が際立った2017年の運用要因を分析し、再現可能性を検証します。
 - マイナスリターンとなった2018年の市場環境とポジションを振り返り、防衛的な戦略に反映させます。
+
+## 2020年ポートフォリオ上位10銘柄
+
+- 1. CHUGAI PHARMACEUTICAL CO., LTD.（4519.T）: 20.0%
+- 2. CASIO COMPUTER CO., LTD.（6952.T）: 20.0%
+- 3. NTT, INC.（9432.T）: 15.8%
+- 4. FUJITSU LTD.（6702.T）: 9.7%
+- 5. ADVANTEST CORP.（6857.T）: 8.0%
+- 6. DAIICHI SANKYO CO., LTD.（4568.T）: 6.8%
+- 7. SONY GROUP CORP.（6758.T）: 6.3%
+- 8. BANDAI NAMCO HOLDINGS INC.（7832.T）: 5.8%
+- 9. ASTELLAS PHARMA INC.（4503.T）: 4.0%
+- 10. NINTENDO CO., LTD.（7974.T）: 1.9%

--- a/src/reporting/yaml_reporter.py
+++ b/src/reporting/yaml_reporter.py
@@ -48,7 +48,25 @@ def write_reports(results, directory):
     for year, payload in rounded.items():
         (directory / f"{year}.yaml").write_text("\n".join(_yaml_lines(payload)) + "\n", encoding="utf-8")
     if rounded:
-        summary = {str(year): payload["portfolio"]["risk_metrics"] for year, payload in rounded.items()}
+        summary = {
+            str(year): payload["portfolio"]["risk_metrics"]
+            for year, payload in rounded.items()
+        }
+        holdings = {
+            str(year): [
+                {
+                    "ticker": ticker,
+                    "name": weight_data.get("name", ""),
+                    "weight": float(weight_data.get("weight", 0.0)),
+                }
+                for ticker, weight_data in sorted(
+                    payload["portfolio"]["weights"].items(),
+                    key=lambda item: item[1].get("weight", 0.0),
+                    reverse=True,
+                )[:10]
+            ]
+            for year, payload in rounded.items()
+        }
         (directory / "summary.yaml").write_text("\n".join(_yaml_lines({"years": summary})) + "\n", encoding="utf-8")
-        report = render_summary_report(summary)
+        report = render_summary_report(summary, holdings)
         (directory / "summary_report.md").write_text(report, encoding="utf-8")


### PR DESCRIPTION
## Summary
- include optional top-holdings data when rendering the portfolio summary report
- extract the top ten holdings per year during report generation and add them to the static markdown output

## Testing
- python -m compileall src/reporting

------
https://chatgpt.com/codex/tasks/task_e_68e4c98c85708325a7e1465e6b68c344