### PR TITLE
Use adjusted close prices when ingesting yfinance data

### DIFF
--- a/src/ingestion/yfinance_client.py
+++ b/src/ingestion/yfinance_client.py
@@ -4,7 +4,14 @@ from zoneinfo import ZoneInfo
 
 
 def fetch_series(ticker, start, end, timezone):
-    data = yf.download(ticker, start=start, end=end, interval="1d", auto_adjust=False, progress=False)[["Close", "Volume"]]
+    data = yf.download(
+        ticker,
+        start=start,
+        end=end,
+        interval="1d",
+        auto_adjust=False,
+        progress=False,
+    )[["Adj Close", "Volume"]]
     data.columns = ["close", "volume"]
     index = pd.DatetimeIndex(data.index).tz_localize("UTC").tz_convert(ZoneInfo(timezone))
     data.index = index


### PR DESCRIPTION
## Summary
- replace raw closing prices with adjusted closes when downloading daily data from yfinance to account for splits and dividends

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e4ca5a7f4083258972e948bb3f6ea1