### PR TITLE
Refine YAML portfolio reporting structure

### DIFF
--- a/reports/portfolio/2013.yaml
+++ b/reports/portfolio/2013.yaml
@@ -1,437 +1,605 @@
+year: 2013
 period:
   start: 2013-01-01
   end: 2013-12-31
-universe:
-  -
-    ticker: 1332.T
-    name: Nissui
-  -
-    ticker: 4061.T
-    name: Denka
-  -
-    ticker: 5714.T
-    name: DOWA Holdings
-  -
-    ticker: 7011.T
-    name: Mitsubishi Heavy Industries
-  -
-    ticker: 8604.T
-    name: NOMURA HOLDINGS, INC.
-  -
-    ticker: 4063.T
-    name: Shin-Etsu Chemical
-  -
-    ticker: 7012.T
-    name: Kawasaki Heavy Industries
-  -
-    ticker: 1605.T
-    name: Inpex Corp
-  -
-    ticker: 4151.T
-    name: KYOWA KIRIN CO., LTD.
-  -
-    ticker: 4502.T
-    name: TAKEDA PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4503.T
-    name: ASTELLAS PHARMA INC.
-  -
-    ticker: 4506.T
-    name: SUMITOMO PHARMA CO., LTD.
-  -
-    ticker: 4507.T
-    name: SHIONOGI & CO., LTD.
-  -
-    ticker: 4519.T
-    name: CHUGAI PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4523.T
-    name: EISAI CO., LTD.
-  -
-    ticker: 4568.T
-    name: DAIICHI SANKYO CO., LTD.
-  -
-    ticker: 6479.T
-    name: MINEBEA MITSUMI INC.
-  -
-    ticker: 6501.T
-    name: HITACHI, LTD.
-  -
-    ticker: 6503.T
-    name: MITSUBISHI ELECTRIC CORP.
-  -
-    ticker: 6504.T
-    name: FUJI ELECTRIC CO., LTD.
-  -
-    ticker: 6506.T
-    name: YASKAWA ELECTRIC CORP.
-  -
-    ticker: 6594.T
-    name: NIDEC CORP.
-  -
-    ticker: 6645.T
-    name: OMRON CORP.
-  -
-    ticker: 6674.T
-    name: GS YUASA CORP.
-  -
-    ticker: 6701.T
-    name: NEC CORP.
-  -
-    ticker: 6702.T
-    name: FUJITSU LTD.
-  -
-    ticker: 6723.T
-    name: RENESAS ELECTRONICS CORP.
-  -
-    ticker: 6724.T
-    name: SEIKO EPSON CORP.
-  -
-    ticker: 6752.T
-    name: PANASONIC HOLDINGS CORP.
-  -
-    ticker: 6753.T
-    name: SHARP CORP.
-  -
-    ticker: 6758.T
-    name: SONY GROUP CORP.
-  -
-    ticker: 6762.T
-    name: TDK CORP.
-  -
-    ticker: 6770.T
-    name: ALPS ALPINE CO., LTD.
-  -
-    ticker: 6841.T
-    name: YOKOGAWA ELECTRIC CORP.
-  -
-    ticker: 6857.T
-    name: ADVANTEST CORP.
-  -
-    ticker: 6861.T
-    name: KEYENCE CORP.
-  -
-    ticker: 6902.T
-    name: DENSO CORP.
-  -
-    ticker: 6952.T
-    name: CASIO COMPUTER CO., LTD.
-  -
-    ticker: 6954.T
-    name: FANUC CORP.
-  -
-    ticker: 6963.T
-    name: ROHM CO., LTD.
-  -
-    ticker: 9984.T
-    name: SOFTBANK GROUP CORP.
-  -
-    ticker: 8306.T
-    name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-  -
-    ticker: 8316.T
-    name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-  -
-    ticker: 7974.T
-    name: NINTENDO CO., LTD.
-  -
-    ticker: 9983.T
-    name: FAST RETAILING CO., LTD.
-  -
-    ticker: 9432.T
-    name: NTT, INC.
-  -
-    ticker: 8411.T
-    name: MIZUHO FINANCIAL GROUP, INC.
-  -
-    ticker: 8766.T
-    name: TOKIO MARINE HOLDINGS, INC.
-  -
-    ticker: 8031.T
-    name: MITSUI & CO., LTD.
-  -
-    ticker: 2914.T
-    name: JAPAN TOBACCO INC.
-  -
-    ticker: 7267.T
-    name: HONDA MOTOR CO., LTD.
-  -
-    ticker: 4661.T
-    name: ORIENTAL LAND CO., LTD.
-  -
-    ticker: 6981.T
-    name: MURATA MANUFACTURING CO., LTD.
-  -
-    ticker: 6367.T
-    name: DAIKIN INDUSTRIES,LTD.
-  -
-    ticker: 8725.T
-    name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-  -
-    ticker: 3382.T
-    name: SEVEN & I HOLDINGS CO., LTD.
-  -
-    ticker: 6301.T
-    name: KOMATSU LTD.
-  -
-    ticker: 8267.T
-    name: AEON CO., LTD.
-  -
-    ticker: 8801.T
-    name: MITSUI FUDOSAN CO., LTD.
-  -
-    ticker: 2802.T
-    name: AJINOMOTO CO., INC.
-  -
-    ticker: 8802.T
-    name: MITSUBISHI ESTATE CO., LTD.
-  -
-    ticker: 5803.T
-    name: FUJIKURA LTD.
-  -
-    ticker: 7751.T
-    name: CANON INC.
-  -
-    ticker: 8308.T
-    name: RESONA HOLDINGS, INC.
-  -
-    ticker: 5802.T
-    name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-  -
-    ticker: 9613.T
-    name: NOMURA RESEARCH INSTITUTE, LTD.
-  -
-    ticker: 1925.T
-    name: DAIWA HOUSE INDUSTRY CO., LTD.
-  -
-    ticker: 7832.T
-    name: BANDAI NAMCO HOLDINGS INC.
-  -
-    ticker: 8830.T
-    name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-  -
-    ticker: 8309.T
-    name: SUMITOMO MITSUI TRUST GROUP, INC.
+conditions:
+  training_window:
+    start: 2012-04-24 09:00:00+09:00
+    end: 2012-12-28 09:00:00+09:00
+  evaluation_window:
+    start: 2013-01-04 09:00:00+09:00
+    end: 2013-12-30 09:00:00+09:00
 portfolio:
-  weights:
-    1332.T:
-      name: Nissui
-      weight: 0.000000
-    4061.T:
-      name: Denka
-      weight: 0.000000
-    5714.T:
-      name: DOWA Holdings
-      weight: 0.000000
-    7011.T:
-      name: Mitsubishi Heavy Industries
-      weight: 0.000000
-    8604.T:
-      name: NOMURA HOLDINGS, INC.
-      weight: 0.000000
-    4063.T:
-      name: Shin-Etsu Chemical
-      weight: 0.000000
-    7012.T:
-      name: Kawasaki Heavy Industries
-      weight: 0.000000
-    1605.T:
-      name: Inpex Corp
-      weight: 0.000000
-    4151.T:
-      name: KYOWA KIRIN CO., LTD.
-      weight: 0.000000
-    4502.T:
-      name: TAKEDA PHARMACEUTICAL CO., LTD.
-      weight: 0.000000
-    4503.T:
-      name: ASTELLAS PHARMA INC.
-      weight: 0.000000
-    4506.T:
-      name: SUMITOMO PHARMA CO., LTD.
-      weight: 0.046450
-    4507.T:
-      name: SHIONOGI & CO., LTD.
-      weight: 0.181232
-    4519.T:
-      name: CHUGAI PHARMACEUTICAL CO., LTD.
-      weight: 0.000000
-    4523.T:
-      name: EISAI CO., LTD.
-      weight: 0.042910
-    4568.T:
-      name: DAIICHI SANKYO CO., LTD.
-      weight: 0.000000
-    6479.T:
-      name: MINEBEA MITSUMI INC.
-      weight: 0.000000
-    6501.T:
-      name: HITACHI, LTD.
-      weight: 0.000000
-    6503.T:
-      name: MITSUBISHI ELECTRIC CORP.
-      weight: 0.000000
-    6504.T:
-      name: FUJI ELECTRIC CO., LTD.
-      weight: 0.000000
-    6506.T:
-      name: YASKAWA ELECTRIC CORP.
-      weight: 0.000000
-    6594.T:
-      name: NIDEC CORP.
-      weight: 0.000000
-    6645.T:
-      name: OMRON CORP.
-      weight: 0.020290
-    6674.T:
-      name: GS YUASA CORP.
-      weight: 0.000000
-    6701.T:
-      name: NEC CORP.
-      weight: 0.003106
-    6702.T:
-      name: FUJITSU LTD.
-      weight: 0.000000
-    6723.T:
-      name: RENESAS ELECTRONICS CORP.
-      weight: 0.000000
-    6724.T:
-      name: SEIKO EPSON CORP.
-      weight: 0.000000
-    6752.T:
-      name: PANASONIC HOLDINGS CORP.
-      weight: 0.000000
-    6753.T:
-      name: SHARP CORP.
-      weight: 0.000000
-    6758.T:
-      name: SONY GROUP CORP.
-      weight: 0.000000
-    6762.T:
-      name: TDK CORP.
-      weight: 0.000000
-    6770.T:
-      name: ALPS ALPINE CO., LTD.
-      weight: 0.000000
-    6841.T:
-      name: YOKOGAWA ELECTRIC CORP.
-      weight: 0.000000
-    6857.T:
-      name: ADVANTEST CORP.
-      weight: 0.000000
-    6861.T:
-      name: KEYENCE CORP.
-      weight: 0.070516
-    6902.T:
-      name: DENSO CORP.
-      weight: 0.000000
-    6952.T:
-      name: CASIO COMPUTER CO., LTD.
-      weight: 0.000000
-    6954.T:
-      name: FANUC CORP.
-      weight: 0.000000
-    6963.T:
-      name: ROHM CO., LTD.
-      weight: 0.000000
-    9984.T:
-      name: SOFTBANK GROUP CORP.
-      weight: 0.080612
-    8306.T:
-      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8316.T:
-      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-      weight: 0.000000
-    7974.T:
-      name: NINTENDO CO., LTD.
-      weight: 0.000000
-    9983.T:
-      name: FAST RETAILING CO., LTD.
-      weight: 0.001602
-    9432.T:
-      name: NTT, INC.
-      weight: 0.000000
-    8411.T:
-      name: MIZUHO FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8766.T:
-      name: TOKIO MARINE HOLDINGS, INC.
-      weight: 0.000000
-    8031.T:
-      name: MITSUI & CO., LTD.
-      weight: 0.000000
-    2914.T:
-      name: JAPAN TOBACCO INC.
-      weight: 0.000000
-    7267.T:
-      name: HONDA MOTOR CO., LTD.
-      weight: 0.000000
-    4661.T:
-      name: ORIENTAL LAND CO., LTD.
-      weight: 0.200000
-    6981.T:
-      name: MURATA MANUFACTURING CO., LTD.
-      weight: 0.000000
-    6367.T:
-      name: DAIKIN INDUSTRIES,LTD.
-      weight: 0.081232
-    8725.T:
-      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-      weight: 0.000000
-    3382.T:
-      name: SEVEN & I HOLDINGS CO., LTD.
-      weight: 0.000000
-    6301.T:
-      name: KOMATSU LTD.
-      weight: 0.000000
-    8267.T:
-      name: AEON CO., LTD.
-      weight: 0.000000
-    8801.T:
-      name: MITSUI FUDOSAN CO., LTD.
-      weight: 0.000000
-    2802.T:
-      name: AJINOMOTO CO., INC.
-      weight: 0.015578
-    8802.T:
-      name: MITSUBISHI ESTATE CO., LTD.
-      weight: 0.033000
-    5803.T:
-      name: FUJIKURA LTD.
-      weight: 0.000000
-    7751.T:
-      name: CANON INC.
-      weight: 0.000000
-    8308.T:
-      name: RESONA HOLDINGS, INC.
-      weight: 0.000000
-    5802.T:
-      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-      weight: 0.000000
-    9613.T:
-      name: NOMURA RESEARCH INSTITUTE, LTD.
-      weight: 0.000000
-    1925.T:
-      name: DAIWA HOUSE INDUSTRY CO., LTD.
-      weight: 0.200000
-    7832.T:
-      name: BANDAI NAMCO HOLDINGS INC.
-      weight: 0.000000
-    8830.T:
-      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-      weight: 0.023472
-    8309.T:
-      name: SUMITOMO MITSUI TRUST GROUP, INC.
-      weight: 0.000000
   risk_metrics:
     annual_return: 0.569277
     volatility: 0.247648
     sharpe_ratio: 2.298731
     max_drawdown: -0.174918
-  training_window:
-    start: 2012-04-24T09:00:00+09:00
-    end: 2012-12-28T09:00:00+09:00
-  evaluation_window:
-    start: 2013-01-04T09:00:00+09:00
-    end: 2013-12-30T09:00:00+09:00
+  allocations:
+    summary:
+      total_constituents: 70
+      invested_constituents: 14
+      zero_weight_constituents: 56
+      top3_weight: 0.581232
+      top10_weight: 0.959424
+    top_holdings:
+      -
+        rank: 1
+        ticker: 4661.T
+        name: ORIENTAL LAND CO., LTD.
+        weight: 0.200000
+      -
+        rank: 2
+        ticker: 1925.T
+        name: DAIWA HOUSE INDUSTRY CO., LTD.
+        weight: 0.200000
+      -
+        rank: 3
+        ticker: 4507.T
+        name: SHIONOGI & CO., LTD.
+        weight: 0.181232
+      -
+        rank: 4
+        ticker: 6367.T
+        name: DAIKIN INDUSTRIES,LTD.
+        weight: 0.081232
+      -
+        rank: 5
+        ticker: 9984.T
+        name: SOFTBANK GROUP CORP.
+        weight: 0.080612
+      -
+        rank: 6
+        ticker: 6861.T
+        name: KEYENCE CORP.
+        weight: 0.070516
+      -
+        rank: 7
+        ticker: 4506.T
+        name: SUMITOMO PHARMA CO., LTD.
+        weight: 0.046450
+      -
+        rank: 8
+        ticker: 4523.T
+        name: EISAI CO., LTD.
+        weight: 0.042910
+      -
+        rank: 9
+        ticker: 8802.T
+        name: MITSUBISHI ESTATE CO., LTD.
+        weight: 0.033000
+      -
+        rank: 10
+        ticker: 8830.T
+        name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+        weight: 0.023472
+    smallest_active_weights:
+      -
+        ticker: 9983.T
+        name: FAST RETAILING CO., LTD.
+        weight: 0.001602
+      -
+        ticker: 6701.T
+        name: NEC CORP.
+        weight: 0.003106
+      -
+        ticker: 2802.T
+        name: AJINOMOTO CO., INC.
+        weight: 0.015578
+      -
+        ticker: 6645.T
+        name: OMRON CORP.
+        weight: 0.020290
+      -
+        ticker: 8830.T
+        name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+        weight: 0.023472
+    weight_buckets:
+      -
+        label: 10%以上
+        count: 3
+        weight_share: 0.581232
+        sample:
+          -
+            ticker: 4661.T
+            name: ORIENTAL LAND CO., LTD.
+            weight: 0.200000
+          -
+            ticker: 1925.T
+            name: DAIWA HOUSE INDUSTRY CO., LTD.
+            weight: 0.200000
+          -
+            ticker: 4507.T
+            name: SHIONOGI & CO., LTD.
+            weight: 0.181232
+      -
+        label: 5%-10%
+        count: 3
+        weight_share: 0.232360
+        sample:
+          -
+            ticker: 6367.T
+            name: DAIKIN INDUSTRIES,LTD.
+            weight: 0.081232
+          -
+            ticker: 9984.T
+            name: SOFTBANK GROUP CORP.
+            weight: 0.080612
+          -
+            ticker: 6861.T
+            name: KEYENCE CORP.
+            weight: 0.070516
+      -
+        label: 1%-5%
+        count: 6
+        weight_share: 0.181700
+        sample:
+          -
+            ticker: 4506.T
+            name: SUMITOMO PHARMA CO., LTD.
+            weight: 0.046450
+          -
+            ticker: 4523.T
+            name: EISAI CO., LTD.
+            weight: 0.042910
+          -
+            ticker: 8802.T
+            name: MITSUBISHI ESTATE CO., LTD.
+            weight: 0.033000
+          -
+            ticker: 8830.T
+            name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+            weight: 0.023472
+          -
+            ticker: 6645.T
+            name: OMRON CORP.
+            weight: 0.020290
+      -
+        label: 1%未満
+        count: 58
+        weight_share: 0.004708
+        sample:
+          -
+            ticker: 6701.T
+            name: NEC CORP.
+            weight: 0.003106
+          -
+            ticker: 9983.T
+            name: FAST RETAILING CO., LTD.
+            weight: 0.001602
+          -
+            ticker: 1332.T
+            name: Nissui
+            weight: 0.000000
+          -
+            ticker: 4061.T
+            name: Denka
+            weight: 0.000000
+          -
+            ticker: 5714.T
+            name: DOWA Holdings
+            weight: 0.000000
+    by_ticker:
+      1332.T:
+        name: Nissui
+        weight: 0.000000
+      1605.T:
+        name: Inpex Corp
+        weight: 0.000000
+      1925.T:
+        name: DAIWA HOUSE INDUSTRY CO., LTD.
+        weight: 0.200000
+      2802.T:
+        name: AJINOMOTO CO., INC.
+        weight: 0.015578
+      2914.T:
+        name: JAPAN TOBACCO INC.
+        weight: 0.000000
+      3382.T:
+        name: SEVEN & I HOLDINGS CO., LTD.
+        weight: 0.000000
+      4061.T:
+        name: Denka
+        weight: 0.000000
+      4063.T:
+        name: Shin-Etsu Chemical
+        weight: 0.000000
+      4151.T:
+        name: KYOWA KIRIN CO., LTD.
+        weight: 0.000000
+      4502.T:
+        name: TAKEDA PHARMACEUTICAL CO., LTD.
+        weight: 0.000000
+      4503.T:
+        name: ASTELLAS PHARMA INC.
+        weight: 0.000000
+      4506.T:
+        name: SUMITOMO PHARMA CO., LTD.
+        weight: 0.046450
+      4507.T:
+        name: SHIONOGI & CO., LTD.
+        weight: 0.181232
+      4519.T:
+        name: CHUGAI PHARMACEUTICAL CO., LTD.
+        weight: 0.000000
+      4523.T:
+        name: EISAI CO., LTD.
+        weight: 0.042910
+      4568.T:
+        name: DAIICHI SANKYO CO., LTD.
+        weight: 0.000000
+      4661.T:
+        name: ORIENTAL LAND CO., LTD.
+        weight: 0.200000
+      5714.T:
+        name: DOWA Holdings
+        weight: 0.000000
+      5802.T:
+        name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+        weight: 0.000000
+      5803.T:
+        name: FUJIKURA LTD.
+        weight: 0.000000
+      6301.T:
+        name: KOMATSU LTD.
+        weight: 0.000000
+      6367.T:
+        name: DAIKIN INDUSTRIES,LTD.
+        weight: 0.081232
+      6479.T:
+        name: MINEBEA MITSUMI INC.
+        weight: 0.000000
+      6501.T:
+        name: HITACHI, LTD.
+        weight: 0.000000
+      6503.T:
+        name: MITSUBISHI ELECTRIC CORP.
+        weight: 0.000000
+      6504.T:
+        name: FUJI ELECTRIC CO., LTD.
+        weight: 0.000000
+      6506.T:
+        name: YASKAWA ELECTRIC CORP.
+        weight: 0.000000
+      6594.T:
+        name: NIDEC CORP.
+        weight: 0.000000
+      6645.T:
+        name: OMRON CORP.
+        weight: 0.020290
+      6674.T:
+        name: GS YUASA CORP.
+        weight: 0.000000
+      6701.T:
+        name: NEC CORP.
+        weight: 0.003106
+      6702.T:
+        name: FUJITSU LTD.
+        weight: 0.000000
+      6723.T:
+        name: RENESAS ELECTRONICS CORP.
+        weight: 0.000000
+      6724.T:
+        name: SEIKO EPSON CORP.
+        weight: 0.000000
+      6752.T:
+        name: PANASONIC HOLDINGS CORP.
+        weight: 0.000000
+      6753.T:
+        name: SHARP CORP.
+        weight: 0.000000
+      6758.T:
+        name: SONY GROUP CORP.
+        weight: 0.000000
+      6762.T:
+        name: TDK CORP.
+        weight: 0.000000
+      6770.T:
+        name: ALPS ALPINE CO., LTD.
+        weight: 0.000000
+      6841.T:
+        name: YOKOGAWA ELECTRIC CORP.
+        weight: 0.000000
+      6857.T:
+        name: ADVANTEST CORP.
+        weight: 0.000000
+      6861.T:
+        name: KEYENCE CORP.
+        weight: 0.070516
+      6902.T:
+        name: DENSO CORP.
+        weight: 0.000000
+      6952.T:
+        name: CASIO COMPUTER CO., LTD.
+        weight: 0.000000
+      6954.T:
+        name: FANUC CORP.
+        weight: 0.000000
+      6963.T:
+        name: ROHM CO., LTD.
+        weight: 0.000000
+      6981.T:
+        name: MURATA MANUFACTURING CO., LTD.
+        weight: 0.000000
+      7011.T:
+        name: Mitsubishi Heavy Industries
+        weight: 0.000000
+      7012.T:
+        name: Kawasaki Heavy Industries
+        weight: 0.000000
+      7267.T:
+        name: HONDA MOTOR CO., LTD.
+        weight: 0.000000
+      7751.T:
+        name: CANON INC.
+        weight: 0.000000
+      7832.T:
+        name: BANDAI NAMCO HOLDINGS INC.
+        weight: 0.000000
+      7974.T:
+        name: NINTENDO CO., LTD.
+        weight: 0.000000
+      8031.T:
+        name: MITSUI & CO., LTD.
+        weight: 0.000000
+      8267.T:
+        name: AEON CO., LTD.
+        weight: 0.000000
+      8306.T:
+        name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8308.T:
+        name: RESONA HOLDINGS, INC.
+        weight: 0.000000
+      8309.T:
+        name: SUMITOMO MITSUI TRUST GROUP, INC.
+        weight: 0.000000
+      8316.T:
+        name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8411.T:
+        name: MIZUHO FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8604.T:
+        name: NOMURA HOLDINGS, INC.
+        weight: 0.000000
+      8725.T:
+        name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+        weight: 0.000000
+      8766.T:
+        name: TOKIO MARINE HOLDINGS, INC.
+        weight: 0.000000
+      8801.T:
+        name: MITSUI FUDOSAN CO., LTD.
+        weight: 0.000000
+      8802.T:
+        name: MITSUBISHI ESTATE CO., LTD.
+        weight: 0.033000
+      8830.T:
+        name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+        weight: 0.023472
+      9432.T:
+        name: NTT, INC.
+        weight: 0.000000
+      9613.T:
+        name: NOMURA RESEARCH INSTITUTE, LTD.
+        weight: 0.000000
+      9983.T:
+        name: FAST RETAILING CO., LTD.
+        weight: 0.001602
+      9984.T:
+        name: SOFTBANK GROUP CORP.
+        weight: 0.080612
+universe:
+  count: 70
+  members:
+    -
+      ticker: 1332.T
+      name: Nissui
+    -
+      ticker: 1605.T
+      name: Inpex Corp
+    -
+      ticker: 1925.T
+      name: DAIWA HOUSE INDUSTRY CO., LTD.
+    -
+      ticker: 2802.T
+      name: AJINOMOTO CO., INC.
+    -
+      ticker: 2914.T
+      name: JAPAN TOBACCO INC.
+    -
+      ticker: 3382.T
+      name: SEVEN & I HOLDINGS CO., LTD.
+    -
+      ticker: 4061.T
+      name: Denka
+    -
+      ticker: 4063.T
+      name: Shin-Etsu Chemical
+    -
+      ticker: 4151.T
+      name: KYOWA KIRIN CO., LTD.
+    -
+      ticker: 4502.T
+      name: TAKEDA PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4503.T
+      name: ASTELLAS PHARMA INC.
+    -
+      ticker: 4506.T
+      name: SUMITOMO PHARMA CO., LTD.
+    -
+      ticker: 4507.T
+      name: SHIONOGI & CO., LTD.
+    -
+      ticker: 4519.T
+      name: CHUGAI PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4523.T
+      name: EISAI CO., LTD.
+    -
+      ticker: 4568.T
+      name: DAIICHI SANKYO CO., LTD.
+    -
+      ticker: 4661.T
+      name: ORIENTAL LAND CO., LTD.
+    -
+      ticker: 5714.T
+      name: DOWA Holdings
+    -
+      ticker: 5802.T
+      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+    -
+      ticker: 5803.T
+      name: FUJIKURA LTD.
+    -
+      ticker: 6301.T
+      name: KOMATSU LTD.
+    -
+      ticker: 6367.T
+      name: DAIKIN INDUSTRIES,LTD.
+    -
+      ticker: 6479.T
+      name: MINEBEA MITSUMI INC.
+    -
+      ticker: 6501.T
+      name: HITACHI, LTD.
+    -
+      ticker: 6503.T
+      name: MITSUBISHI ELECTRIC CORP.
+    -
+      ticker: 6504.T
+      name: FUJI ELECTRIC CO., LTD.
+    -
+      ticker: 6506.T
+      name: YASKAWA ELECTRIC CORP.
+    -
+      ticker: 6594.T
+      name: NIDEC CORP.
+    -
+      ticker: 6645.T
+      name: OMRON CORP.
+    -
+      ticker: 6674.T
+      name: GS YUASA CORP.
+    -
+      ticker: 6701.T
+      name: NEC CORP.
+    -
+      ticker: 6702.T
+      name: FUJITSU LTD.
+    -
+      ticker: 6723.T
+      name: RENESAS ELECTRONICS CORP.
+    -
+      ticker: 6724.T
+      name: SEIKO EPSON CORP.
+    -
+      ticker: 6752.T
+      name: PANASONIC HOLDINGS CORP.
+    -
+      ticker: 6753.T
+      name: SHARP CORP.
+    -
+      ticker: 6758.T
+      name: SONY GROUP CORP.
+    -
+      ticker: 6762.T
+      name: TDK CORP.
+    -
+      ticker: 6770.T
+      name: ALPS ALPINE CO., LTD.
+    -
+      ticker: 6841.T
+      name: YOKOGAWA ELECTRIC CORP.
+    -
+      ticker: 6857.T
+      name: ADVANTEST CORP.
+    -
+      ticker: 6861.T
+      name: KEYENCE CORP.
+    -
+      ticker: 6902.T
+      name: DENSO CORP.
+    -
+      ticker: 6952.T
+      name: CASIO COMPUTER CO., LTD.
+    -
+      ticker: 6954.T
+      name: FANUC CORP.
+    -
+      ticker: 6963.T
+      name: ROHM CO., LTD.
+    -
+      ticker: 6981.T
+      name: MURATA MANUFACTURING CO., LTD.
+    -
+      ticker: 7011.T
+      name: Mitsubishi Heavy Industries
+    -
+      ticker: 7012.T
+      name: Kawasaki Heavy Industries
+    -
+      ticker: 7267.T
+      name: HONDA MOTOR CO., LTD.
+    -
+      ticker: 7751.T
+      name: CANON INC.
+    -
+      ticker: 7832.T
+      name: BANDAI NAMCO HOLDINGS INC.
+    -
+      ticker: 7974.T
+      name: NINTENDO CO., LTD.
+    -
+      ticker: 8031.T
+      name: MITSUI & CO., LTD.
+    -
+      ticker: 8267.T
+      name: AEON CO., LTD.
+    -
+      ticker: 8306.T
+      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+    -
+      ticker: 8308.T
+      name: RESONA HOLDINGS, INC.
+    -
+      ticker: 8309.T
+      name: SUMITOMO MITSUI TRUST GROUP, INC.
+    -
+      ticker: 8316.T
+      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+    -
+      ticker: 8411.T
+      name: MIZUHO FINANCIAL GROUP, INC.
+    -
+      ticker: 8604.T
+      name: NOMURA HOLDINGS, INC.
+    -
+      ticker: 8725.T
+      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+    -
+      ticker: 8766.T
+      name: TOKIO MARINE HOLDINGS, INC.
+    -
+      ticker: 8801.T
+      name: MITSUI FUDOSAN CO., LTD.
+    -
+      ticker: 8802.T
+      name: MITSUBISHI ESTATE CO., LTD.
+    -
+      ticker: 8830.T
+      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+    -
+      ticker: 9432.T
+      name: NTT, INC.
+    -
+      ticker: 9613.T
+      name: NOMURA RESEARCH INSTITUTE, LTD.
+    -
+      ticker: 9983.T
+      name: FAST RETAILING CO., LTD.
+    -
+      ticker: 9984.T
+      name: SOFTBANK GROUP CORP.

--- a/reports/portfolio/2014.yaml
+++ b/reports/portfolio/2014.yaml
@@ -1,437 +1,593 @@
+year: 2014
 period:
   start: 2014-01-01
   end: 2014-12-31
-universe:
-  -
-    ticker: 1332.T
-    name: Nissui
-  -
-    ticker: 4061.T
-    name: Denka
-  -
-    ticker: 5714.T
-    name: DOWA Holdings
-  -
-    ticker: 7011.T
-    name: Mitsubishi Heavy Industries
-  -
-    ticker: 8604.T
-    name: NOMURA HOLDINGS, INC.
-  -
-    ticker: 4063.T
-    name: Shin-Etsu Chemical
-  -
-    ticker: 7012.T
-    name: Kawasaki Heavy Industries
-  -
-    ticker: 1605.T
-    name: Inpex Corp
-  -
-    ticker: 4151.T
-    name: KYOWA KIRIN CO., LTD.
-  -
-    ticker: 4502.T
-    name: TAKEDA PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4503.T
-    name: ASTELLAS PHARMA INC.
-  -
-    ticker: 4506.T
-    name: SUMITOMO PHARMA CO., LTD.
-  -
-    ticker: 4507.T
-    name: SHIONOGI & CO., LTD.
-  -
-    ticker: 4519.T
-    name: CHUGAI PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4523.T
-    name: EISAI CO., LTD.
-  -
-    ticker: 4568.T
-    name: DAIICHI SANKYO CO., LTD.
-  -
-    ticker: 6479.T
-    name: MINEBEA MITSUMI INC.
-  -
-    ticker: 6501.T
-    name: HITACHI, LTD.
-  -
-    ticker: 6503.T
-    name: MITSUBISHI ELECTRIC CORP.
-  -
-    ticker: 6504.T
-    name: FUJI ELECTRIC CO., LTD.
-  -
-    ticker: 6506.T
-    name: YASKAWA ELECTRIC CORP.
-  -
-    ticker: 6594.T
-    name: NIDEC CORP.
-  -
-    ticker: 6645.T
-    name: OMRON CORP.
-  -
-    ticker: 6674.T
-    name: GS YUASA CORP.
-  -
-    ticker: 6701.T
-    name: NEC CORP.
-  -
-    ticker: 6702.T
-    name: FUJITSU LTD.
-  -
-    ticker: 6723.T
-    name: RENESAS ELECTRONICS CORP.
-  -
-    ticker: 6724.T
-    name: SEIKO EPSON CORP.
-  -
-    ticker: 6752.T
-    name: PANASONIC HOLDINGS CORP.
-  -
-    ticker: 6753.T
-    name: SHARP CORP.
-  -
-    ticker: 6758.T
-    name: SONY GROUP CORP.
-  -
-    ticker: 6762.T
-    name: TDK CORP.
-  -
-    ticker: 6770.T
-    name: ALPS ALPINE CO., LTD.
-  -
-    ticker: 6841.T
-    name: YOKOGAWA ELECTRIC CORP.
-  -
-    ticker: 6857.T
-    name: ADVANTEST CORP.
-  -
-    ticker: 6861.T
-    name: KEYENCE CORP.
-  -
-    ticker: 6902.T
-    name: DENSO CORP.
-  -
-    ticker: 6952.T
-    name: CASIO COMPUTER CO., LTD.
-  -
-    ticker: 6954.T
-    name: FANUC CORP.
-  -
-    ticker: 6963.T
-    name: ROHM CO., LTD.
-  -
-    ticker: 9984.T
-    name: SOFTBANK GROUP CORP.
-  -
-    ticker: 8306.T
-    name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-  -
-    ticker: 8316.T
-    name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-  -
-    ticker: 7974.T
-    name: NINTENDO CO., LTD.
-  -
-    ticker: 9983.T
-    name: FAST RETAILING CO., LTD.
-  -
-    ticker: 9432.T
-    name: NTT, INC.
-  -
-    ticker: 8411.T
-    name: MIZUHO FINANCIAL GROUP, INC.
-  -
-    ticker: 8766.T
-    name: TOKIO MARINE HOLDINGS, INC.
-  -
-    ticker: 8031.T
-    name: MITSUI & CO., LTD.
-  -
-    ticker: 2914.T
-    name: JAPAN TOBACCO INC.
-  -
-    ticker: 7267.T
-    name: HONDA MOTOR CO., LTD.
-  -
-    ticker: 4661.T
-    name: ORIENTAL LAND CO., LTD.
-  -
-    ticker: 6981.T
-    name: MURATA MANUFACTURING CO., LTD.
-  -
-    ticker: 6367.T
-    name: DAIKIN INDUSTRIES,LTD.
-  -
-    ticker: 8725.T
-    name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-  -
-    ticker: 3382.T
-    name: SEVEN & I HOLDINGS CO., LTD.
-  -
-    ticker: 6301.T
-    name: KOMATSU LTD.
-  -
-    ticker: 8267.T
-    name: AEON CO., LTD.
-  -
-    ticker: 8801.T
-    name: MITSUI FUDOSAN CO., LTD.
-  -
-    ticker: 2802.T
-    name: AJINOMOTO CO., INC.
-  -
-    ticker: 8802.T
-    name: MITSUBISHI ESTATE CO., LTD.
-  -
-    ticker: 5803.T
-    name: FUJIKURA LTD.
-  -
-    ticker: 7751.T
-    name: CANON INC.
-  -
-    ticker: 8308.T
-    name: RESONA HOLDINGS, INC.
-  -
-    ticker: 5802.T
-    name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-  -
-    ticker: 9613.T
-    name: NOMURA RESEARCH INSTITUTE, LTD.
-  -
-    ticker: 1925.T
-    name: DAIWA HOUSE INDUSTRY CO., LTD.
-  -
-    ticker: 7832.T
-    name: BANDAI NAMCO HOLDINGS INC.
-  -
-    ticker: 8830.T
-    name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-  -
-    ticker: 8309.T
-    name: SUMITOMO MITSUI TRUST GROUP, INC.
+conditions:
+  training_window:
+    start: 2013-04-24 09:00:00+09:00
+    end: 2013-12-30 09:00:00+09:00
+  evaluation_window:
+    start: 2014-01-06 09:00:00+09:00
+    end: 2014-12-30 09:00:00+09:00
 portfolio:
-  weights:
-    1332.T:
-      name: Nissui
-      weight: 0.000000
-    4061.T:
-      name: Denka
-      weight: 0.000000
-    5714.T:
-      name: DOWA Holdings
-      weight: 0.000000
-    7011.T:
-      name: Mitsubishi Heavy Industries
-      weight: 0.000000
-    8604.T:
-      name: NOMURA HOLDINGS, INC.
-      weight: 0.000000
-    4063.T:
-      name: Shin-Etsu Chemical
-      weight: 0.000000
-    7012.T:
-      name: Kawasaki Heavy Industries
-      weight: 0.000000
-    1605.T:
-      name: Inpex Corp
-      weight: 0.000000
-    4151.T:
-      name: KYOWA KIRIN CO., LTD.
-      weight: 0.000000
-    4502.T:
-      name: TAKEDA PHARMACEUTICAL CO., LTD.
-      weight: 0.000000
-    4503.T:
-      name: ASTELLAS PHARMA INC.
-      weight: 0.000000
-    4506.T:
-      name: SUMITOMO PHARMA CO., LTD.
-      weight: 0.000000
-    4507.T:
-      name: SHIONOGI & CO., LTD.
-      weight: 0.000000
-    4519.T:
-      name: CHUGAI PHARMACEUTICAL CO., LTD.
-      weight: 0.000000
-    4523.T:
-      name: EISAI CO., LTD.
-      weight: 0.000000
-    4568.T:
-      name: DAIICHI SANKYO CO., LTD.
-      weight: 0.000000
-    6479.T:
-      name: MINEBEA MITSUMI INC.
-      weight: 0.200000
-    6501.T:
-      name: HITACHI, LTD.
-      weight: 0.000000
-    6503.T:
-      name: MITSUBISHI ELECTRIC CORP.
-      weight: 0.000000
-    6504.T:
-      name: FUJI ELECTRIC CO., LTD.
-      weight: 0.000000
-    6506.T:
-      name: YASKAWA ELECTRIC CORP.
-      weight: 0.000000
-    6594.T:
-      name: NIDEC CORP.
-      weight: 0.173086
-    6645.T:
-      name: OMRON CORP.
-      weight: 0.000000
-    6674.T:
-      name: GS YUASA CORP.
-      weight: 0.000000
-    6701.T:
-      name: NEC CORP.
-      weight: 0.000000
-    6702.T:
-      name: FUJITSU LTD.
-      weight: 0.000000
-    6723.T:
-      name: RENESAS ELECTRONICS CORP.
-      weight: 0.066743
-    6724.T:
-      name: SEIKO EPSON CORP.
-      weight: 0.200000
-    6752.T:
-      name: PANASONIC HOLDINGS CORP.
-      weight: 0.000000
-    6753.T:
-      name: SHARP CORP.
-      weight: 0.000000
-    6758.T:
-      name: SONY GROUP CORP.
-      weight: 0.000000
-    6762.T:
-      name: TDK CORP.
-      weight: 0.000000
-    6770.T:
-      name: ALPS ALPINE CO., LTD.
-      weight: 0.000000
-    6841.T:
-      name: YOKOGAWA ELECTRIC CORP.
-      weight: 0.105265
-    6857.T:
-      name: ADVANTEST CORP.
-      weight: 0.000000
-    6861.T:
-      name: KEYENCE CORP.
-      weight: 0.018536
-    6902.T:
-      name: DENSO CORP.
-      weight: 0.000000
-    6952.T:
-      name: CASIO COMPUTER CO., LTD.
-      weight: 0.000000
-    6954.T:
-      name: FANUC CORP.
-      weight: 0.000000
-    6963.T:
-      name: ROHM CO., LTD.
-      weight: 0.000000
-    9984.T:
-      name: SOFTBANK GROUP CORP.
-      weight: 0.161501
-    8306.T:
-      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8316.T:
-      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-      weight: 0.000000
-    7974.T:
-      name: NINTENDO CO., LTD.
-      weight: 0.000000
-    9983.T:
-      name: FAST RETAILING CO., LTD.
-      weight: 0.000000
-    9432.T:
-      name: NTT, INC.
-      weight: 0.000000
-    8411.T:
-      name: MIZUHO FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8766.T:
-      name: TOKIO MARINE HOLDINGS, INC.
-      weight: 0.000000
-    8031.T:
-      name: MITSUI & CO., LTD.
-      weight: 0.000000
-    2914.T:
-      name: JAPAN TOBACCO INC.
-      weight: 0.000000
-    7267.T:
-      name: HONDA MOTOR CO., LTD.
-      weight: 0.000000
-    4661.T:
-      name: ORIENTAL LAND CO., LTD.
-      weight: 0.000000
-    6981.T:
-      name: MURATA MANUFACTURING CO., LTD.
-      weight: 0.000000
-    6367.T:
-      name: DAIKIN INDUSTRIES,LTD.
-      weight: 0.074869
-    8725.T:
-      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-      weight: 0.000000
-    3382.T:
-      name: SEVEN & I HOLDINGS CO., LTD.
-      weight: 0.000000
-    6301.T:
-      name: KOMATSU LTD.
-      weight: 0.000000
-    8267.T:
-      name: AEON CO., LTD.
-      weight: 0.000000
-    8801.T:
-      name: MITSUI FUDOSAN CO., LTD.
-      weight: 0.000000
-    2802.T:
-      name: AJINOMOTO CO., INC.
-      weight: 0.000000
-    8802.T:
-      name: MITSUBISHI ESTATE CO., LTD.
-      weight: 0.000000
-    5803.T:
-      name: FUJIKURA LTD.
-      weight: 0.000000
-    7751.T:
-      name: CANON INC.
-      weight: 0.000000
-    8308.T:
-      name: RESONA HOLDINGS, INC.
-      weight: 0.000000
-    5802.T:
-      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-      weight: 0.000000
-    9613.T:
-      name: NOMURA RESEARCH INSTITUTE, LTD.
-      weight: 0.000000
-    1925.T:
-      name: DAIWA HOUSE INDUSTRY CO., LTD.
-      weight: 0.000000
-    7832.T:
-      name: BANDAI NAMCO HOLDINGS INC.
-      weight: 0.000000
-    8830.T:
-      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-      weight: 0.000000
-    8309.T:
-      name: SUMITOMO MITSUI TRUST GROUP, INC.
-      weight: 0.000000
   risk_metrics:
     annual_return: 0.416052
     volatility: 0.262423
     sharpe_ratio: 1.585426
     max_drawdown: -0.153221
-  training_window:
-    start: 2013-04-24T09:00:00+09:00
-    end: 2013-12-30T09:00:00+09:00
-  evaluation_window:
-    start: 2014-01-06T09:00:00+09:00
-    end: 2014-12-30T09:00:00+09:00
+  allocations:
+    summary:
+      total_constituents: 70
+      invested_constituents: 8
+      zero_weight_constituents: 62
+      top3_weight: 0.573086
+      top10_weight: 1.000000
+    top_holdings:
+      -
+        rank: 1
+        ticker: 6479.T
+        name: MINEBEA MITSUMI INC.
+        weight: 0.200000
+      -
+        rank: 2
+        ticker: 6724.T
+        name: SEIKO EPSON CORP.
+        weight: 0.200000
+      -
+        rank: 3
+        ticker: 6594.T
+        name: NIDEC CORP.
+        weight: 0.173086
+      -
+        rank: 4
+        ticker: 9984.T
+        name: SOFTBANK GROUP CORP.
+        weight: 0.161501
+      -
+        rank: 5
+        ticker: 6841.T
+        name: YOKOGAWA ELECTRIC CORP.
+        weight: 0.105265
+      -
+        rank: 6
+        ticker: 6367.T
+        name: DAIKIN INDUSTRIES,LTD.
+        weight: 0.074869
+      -
+        rank: 7
+        ticker: 6723.T
+        name: RENESAS ELECTRONICS CORP.
+        weight: 0.066743
+      -
+        rank: 8
+        ticker: 6861.T
+        name: KEYENCE CORP.
+        weight: 0.018536
+      -
+        rank: 9
+        ticker: 1332.T
+        name: Nissui
+        weight: 0.000000
+      -
+        rank: 10
+        ticker: 4061.T
+        name: Denka
+        weight: 0.000000
+    smallest_active_weights:
+      -
+        ticker: 6861.T
+        name: KEYENCE CORP.
+        weight: 0.018536
+      -
+        ticker: 6723.T
+        name: RENESAS ELECTRONICS CORP.
+        weight: 0.066743
+      -
+        ticker: 6367.T
+        name: DAIKIN INDUSTRIES,LTD.
+        weight: 0.074869
+      -
+        ticker: 6841.T
+        name: YOKOGAWA ELECTRIC CORP.
+        weight: 0.105265
+      -
+        ticker: 9984.T
+        name: SOFTBANK GROUP CORP.
+        weight: 0.161501
+    weight_buckets:
+      -
+        label: 10%以上
+        count: 5
+        weight_share: 0.839852
+        sample:
+          -
+            ticker: 6479.T
+            name: MINEBEA MITSUMI INC.
+            weight: 0.200000
+          -
+            ticker: 6724.T
+            name: SEIKO EPSON CORP.
+            weight: 0.200000
+          -
+            ticker: 6594.T
+            name: NIDEC CORP.
+            weight: 0.173086
+          -
+            ticker: 9984.T
+            name: SOFTBANK GROUP CORP.
+            weight: 0.161501
+          -
+            ticker: 6841.T
+            name: YOKOGAWA ELECTRIC CORP.
+            weight: 0.105265
+      -
+        label: 5%-10%
+        count: 2
+        weight_share: 0.141612
+        sample:
+          -
+            ticker: 6367.T
+            name: DAIKIN INDUSTRIES,LTD.
+            weight: 0.074869
+          -
+            ticker: 6723.T
+            name: RENESAS ELECTRONICS CORP.
+            weight: 0.066743
+      -
+        label: 1%-5%
+        count: 1
+        weight_share: 0.018536
+        sample:
+          -
+            ticker: 6861.T
+            name: KEYENCE CORP.
+            weight: 0.018536
+      -
+        label: 1%未満
+        count: 62
+        weight_share: 0.000000
+        sample:
+          -
+            ticker: 1332.T
+            name: Nissui
+            weight: 0.000000
+          -
+            ticker: 4061.T
+            name: Denka
+            weight: 0.000000
+          -
+            ticker: 5714.T
+            name: DOWA Holdings
+            weight: 0.000000
+          -
+            ticker: 7011.T
+            name: Mitsubishi Heavy Industries
+            weight: 0.000000
+          -
+            ticker: 8604.T
+            name: NOMURA HOLDINGS, INC.
+            weight: 0.000000
+    by_ticker:
+      1332.T:
+        name: Nissui
+        weight: 0.000000
+      1605.T:
+        name: Inpex Corp
+        weight: 0.000000
+      1925.T:
+        name: DAIWA HOUSE INDUSTRY CO., LTD.
+        weight: 0.000000
+      2802.T:
+        name: AJINOMOTO CO., INC.
+        weight: 0.000000
+      2914.T:
+        name: JAPAN TOBACCO INC.
+        weight: 0.000000
+      3382.T:
+        name: SEVEN & I HOLDINGS CO., LTD.
+        weight: 0.000000
+      4061.T:
+        name: Denka
+        weight: 0.000000
+      4063.T:
+        name: Shin-Etsu Chemical
+        weight: 0.000000
+      4151.T:
+        name: KYOWA KIRIN CO., LTD.
+        weight: 0.000000
+      4502.T:
+        name: TAKEDA PHARMACEUTICAL CO., LTD.
+        weight: 0.000000
+      4503.T:
+        name: ASTELLAS PHARMA INC.
+        weight: 0.000000
+      4506.T:
+        name: SUMITOMO PHARMA CO., LTD.
+        weight: 0.000000
+      4507.T:
+        name: SHIONOGI & CO., LTD.
+        weight: 0.000000
+      4519.T:
+        name: CHUGAI PHARMACEUTICAL CO., LTD.
+        weight: 0.000000
+      4523.T:
+        name: EISAI CO., LTD.
+        weight: 0.000000
+      4568.T:
+        name: DAIICHI SANKYO CO., LTD.
+        weight: 0.000000
+      4661.T:
+        name: ORIENTAL LAND CO., LTD.
+        weight: 0.000000
+      5714.T:
+        name: DOWA Holdings
+        weight: 0.000000
+      5802.T:
+        name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+        weight: 0.000000
+      5803.T:
+        name: FUJIKURA LTD.
+        weight: 0.000000
+      6301.T:
+        name: KOMATSU LTD.
+        weight: 0.000000
+      6367.T:
+        name: DAIKIN INDUSTRIES,LTD.
+        weight: 0.074869
+      6479.T:
+        name: MINEBEA MITSUMI INC.
+        weight: 0.200000
+      6501.T:
+        name: HITACHI, LTD.
+        weight: 0.000000
+      6503.T:
+        name: MITSUBISHI ELECTRIC CORP.
+        weight: 0.000000
+      6504.T:
+        name: FUJI ELECTRIC CO., LTD.
+        weight: 0.000000
+      6506.T:
+        name: YASKAWA ELECTRIC CORP.
+        weight: 0.000000
+      6594.T:
+        name: NIDEC CORP.
+        weight: 0.173086
+      6645.T:
+        name: OMRON CORP.
+        weight: 0.000000
+      6674.T:
+        name: GS YUASA CORP.
+        weight: 0.000000
+      6701.T:
+        name: NEC CORP.
+        weight: 0.000000
+      6702.T:
+        name: FUJITSU LTD.
+        weight: 0.000000
+      6723.T:
+        name: RENESAS ELECTRONICS CORP.
+        weight: 0.066743
+      6724.T:
+        name: SEIKO EPSON CORP.
+        weight: 0.200000
+      6752.T:
+        name: PANASONIC HOLDINGS CORP.
+        weight: 0.000000
+      6753.T:
+        name: SHARP CORP.
+        weight: 0.000000
+      6758.T:
+        name: SONY GROUP CORP.
+        weight: 0.000000
+      6762.T:
+        name: TDK CORP.
+        weight: 0.000000
+      6770.T:
+        name: ALPS ALPINE CO., LTD.
+        weight: 0.000000
+      6841.T:
+        name: YOKOGAWA ELECTRIC CORP.
+        weight: 0.105265
+      6857.T:
+        name: ADVANTEST CORP.
+        weight: 0.000000
+      6861.T:
+        name: KEYENCE CORP.
+        weight: 0.018536
+      6902.T:
+        name: DENSO CORP.
+        weight: 0.000000
+      6952.T:
+        name: CASIO COMPUTER CO., LTD.
+        weight: 0.000000
+      6954.T:
+        name: FANUC CORP.
+        weight: 0.000000
+      6963.T:
+        name: ROHM CO., LTD.
+        weight: 0.000000
+      6981.T:
+        name: MURATA MANUFACTURING CO., LTD.
+        weight: 0.000000
+      7011.T:
+        name: Mitsubishi Heavy Industries
+        weight: 0.000000
+      7012.T:
+        name: Kawasaki Heavy Industries
+        weight: 0.000000
+      7267.T:
+        name: HONDA MOTOR CO., LTD.
+        weight: 0.000000
+      7751.T:
+        name: CANON INC.
+        weight: 0.000000
+      7832.T:
+        name: BANDAI NAMCO HOLDINGS INC.
+        weight: 0.000000
+      7974.T:
+        name: NINTENDO CO., LTD.
+        weight: 0.000000
+      8031.T:
+        name: MITSUI & CO., LTD.
+        weight: 0.000000
+      8267.T:
+        name: AEON CO., LTD.
+        weight: 0.000000
+      8306.T:
+        name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8308.T:
+        name: RESONA HOLDINGS, INC.
+        weight: 0.000000
+      8309.T:
+        name: SUMITOMO MITSUI TRUST GROUP, INC.
+        weight: 0.000000
+      8316.T:
+        name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8411.T:
+        name: MIZUHO FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8604.T:
+        name: NOMURA HOLDINGS, INC.
+        weight: 0.000000
+      8725.T:
+        name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+        weight: 0.000000
+      8766.T:
+        name: TOKIO MARINE HOLDINGS, INC.
+        weight: 0.000000
+      8801.T:
+        name: MITSUI FUDOSAN CO., LTD.
+        weight: 0.000000
+      8802.T:
+        name: MITSUBISHI ESTATE CO., LTD.
+        weight: 0.000000
+      8830.T:
+        name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+        weight: 0.000000
+      9432.T:
+        name: NTT, INC.
+        weight: 0.000000
+      9613.T:
+        name: NOMURA RESEARCH INSTITUTE, LTD.
+        weight: 0.000000
+      9983.T:
+        name: FAST RETAILING CO., LTD.
+        weight: 0.000000
+      9984.T:
+        name: SOFTBANK GROUP CORP.
+        weight: 0.161501
+universe:
+  count: 70
+  members:
+    -
+      ticker: 1332.T
+      name: Nissui
+    -
+      ticker: 1605.T
+      name: Inpex Corp
+    -
+      ticker: 1925.T
+      name: DAIWA HOUSE INDUSTRY CO., LTD.
+    -
+      ticker: 2802.T
+      name: AJINOMOTO CO., INC.
+    -
+      ticker: 2914.T
+      name: JAPAN TOBACCO INC.
+    -
+      ticker: 3382.T
+      name: SEVEN & I HOLDINGS CO., LTD.
+    -
+      ticker: 4061.T
+      name: Denka
+    -
+      ticker: 4063.T
+      name: Shin-Etsu Chemical
+    -
+      ticker: 4151.T
+      name: KYOWA KIRIN CO., LTD.
+    -
+      ticker: 4502.T
+      name: TAKEDA PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4503.T
+      name: ASTELLAS PHARMA INC.
+    -
+      ticker: 4506.T
+      name: SUMITOMO PHARMA CO., LTD.
+    -
+      ticker: 4507.T
+      name: SHIONOGI & CO., LTD.
+    -
+      ticker: 4519.T
+      name: CHUGAI PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4523.T
+      name: EISAI CO., LTD.
+    -
+      ticker: 4568.T
+      name: DAIICHI SANKYO CO., LTD.
+    -
+      ticker: 4661.T
+      name: ORIENTAL LAND CO., LTD.
+    -
+      ticker: 5714.T
+      name: DOWA Holdings
+    -
+      ticker: 5802.T
+      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+    -
+      ticker: 5803.T
+      name: FUJIKURA LTD.
+    -
+      ticker: 6301.T
+      name: KOMATSU LTD.
+    -
+      ticker: 6367.T
+      name: DAIKIN INDUSTRIES,LTD.
+    -
+      ticker: 6479.T
+      name: MINEBEA MITSUMI INC.
+    -
+      ticker: 6501.T
+      name: HITACHI, LTD.
+    -
+      ticker: 6503.T
+      name: MITSUBISHI ELECTRIC CORP.
+    -
+      ticker: 6504.T
+      name: FUJI ELECTRIC CO., LTD.
+    -
+      ticker: 6506.T
+      name: YASKAWA ELECTRIC CORP.
+    -
+      ticker: 6594.T
+      name: NIDEC CORP.
+    -
+      ticker: 6645.T
+      name: OMRON CORP.
+    -
+      ticker: 6674.T
+      name: GS YUASA CORP.
+    -
+      ticker: 6701.T
+      name: NEC CORP.
+    -
+      ticker: 6702.T
+      name: FUJITSU LTD.
+    -
+      ticker: 6723.T
+      name: RENESAS ELECTRONICS CORP.
+    -
+      ticker: 6724.T
+      name: SEIKO EPSON CORP.
+    -
+      ticker: 6752.T
+      name: PANASONIC HOLDINGS CORP.
+    -
+      ticker: 6753.T
+      name: SHARP CORP.
+    -
+      ticker: 6758.T
+      name: SONY GROUP CORP.
+    -
+      ticker: 6762.T
+      name: TDK CORP.
+    -
+      ticker: 6770.T
+      name: ALPS ALPINE CO., LTD.
+    -
+      ticker: 6841.T
+      name: YOKOGAWA ELECTRIC CORP.
+    -
+      ticker: 6857.T
+      name: ADVANTEST CORP.
+    -
+      ticker: 6861.T
+      name: KEYENCE CORP.
+    -
+      ticker: 6902.T
+      name: DENSO CORP.
+    -
+      ticker: 6952.T
+      name: CASIO COMPUTER CO., LTD.
+    -
+      ticker: 6954.T
+      name: FANUC CORP.
+    -
+      ticker: 6963.T
+      name: ROHM CO., LTD.
+    -
+      ticker: 6981.T
+      name: MURATA MANUFACTURING CO., LTD.
+    -
+      ticker: 7011.T
+      name: Mitsubishi Heavy Industries
+    -
+      ticker: 7012.T
+      name: Kawasaki Heavy Industries
+    -
+      ticker: 7267.T
+      name: HONDA MOTOR CO., LTD.
+    -
+      ticker: 7751.T
+      name: CANON INC.
+    -
+      ticker: 7832.T
+      name: BANDAI NAMCO HOLDINGS INC.
+    -
+      ticker: 7974.T
+      name: NINTENDO CO., LTD.
+    -
+      ticker: 8031.T
+      name: MITSUI & CO., LTD.
+    -
+      ticker: 8267.T
+      name: AEON CO., LTD.
+    -
+      ticker: 8306.T
+      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+    -
+      ticker: 8308.T
+      name: RESONA HOLDINGS, INC.
+    -
+      ticker: 8309.T
+      name: SUMITOMO MITSUI TRUST GROUP, INC.
+    -
+      ticker: 8316.T
+      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+    -
+      ticker: 8411.T
+      name: MIZUHO FINANCIAL GROUP, INC.
+    -
+      ticker: 8604.T
+      name: NOMURA HOLDINGS, INC.
+    -
+      ticker: 8725.T
+      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+    -
+      ticker: 8766.T
+      name: TOKIO MARINE HOLDINGS, INC.
+    -
+      ticker: 8801.T
+      name: MITSUI FUDOSAN CO., LTD.
+    -
+      ticker: 8802.T
+      name: MITSUBISHI ESTATE CO., LTD.
+    -
+      ticker: 8830.T
+      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+    -
+      ticker: 9432.T
+      name: NTT, INC.
+    -
+      ticker: 9613.T
+      name: NOMURA RESEARCH INSTITUTE, LTD.
+    -
+      ticker: 9983.T
+      name: FAST RETAILING CO., LTD.
+    -
+      ticker: 9984.T
+      name: SOFTBANK GROUP CORP.

--- a/reports/portfolio/2015.yaml
+++ b/reports/portfolio/2015.yaml
@@ -1,437 +1,593 @@
+year: 2015
 period:
   start: 2015-01-01
   end: 2015-12-31
-universe:
-  -
-    ticker: 1332.T
-    name: Nissui
-  -
-    ticker: 4061.T
-    name: Denka
-  -
-    ticker: 5714.T
-    name: DOWA Holdings
-  -
-    ticker: 7011.T
-    name: Mitsubishi Heavy Industries
-  -
-    ticker: 8604.T
-    name: NOMURA HOLDINGS, INC.
-  -
-    ticker: 4063.T
-    name: Shin-Etsu Chemical
-  -
-    ticker: 7012.T
-    name: Kawasaki Heavy Industries
-  -
-    ticker: 1605.T
-    name: Inpex Corp
-  -
-    ticker: 4151.T
-    name: KYOWA KIRIN CO., LTD.
-  -
-    ticker: 4502.T
-    name: TAKEDA PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4503.T
-    name: ASTELLAS PHARMA INC.
-  -
-    ticker: 4506.T
-    name: SUMITOMO PHARMA CO., LTD.
-  -
-    ticker: 4507.T
-    name: SHIONOGI & CO., LTD.
-  -
-    ticker: 4519.T
-    name: CHUGAI PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4523.T
-    name: EISAI CO., LTD.
-  -
-    ticker: 4568.T
-    name: DAIICHI SANKYO CO., LTD.
-  -
-    ticker: 6479.T
-    name: MINEBEA MITSUMI INC.
-  -
-    ticker: 6501.T
-    name: HITACHI, LTD.
-  -
-    ticker: 6503.T
-    name: MITSUBISHI ELECTRIC CORP.
-  -
-    ticker: 6504.T
-    name: FUJI ELECTRIC CO., LTD.
-  -
-    ticker: 6506.T
-    name: YASKAWA ELECTRIC CORP.
-  -
-    ticker: 6594.T
-    name: NIDEC CORP.
-  -
-    ticker: 6645.T
-    name: OMRON CORP.
-  -
-    ticker: 6674.T
-    name: GS YUASA CORP.
-  -
-    ticker: 6701.T
-    name: NEC CORP.
-  -
-    ticker: 6702.T
-    name: FUJITSU LTD.
-  -
-    ticker: 6723.T
-    name: RENESAS ELECTRONICS CORP.
-  -
-    ticker: 6724.T
-    name: SEIKO EPSON CORP.
-  -
-    ticker: 6752.T
-    name: PANASONIC HOLDINGS CORP.
-  -
-    ticker: 6753.T
-    name: SHARP CORP.
-  -
-    ticker: 6758.T
-    name: SONY GROUP CORP.
-  -
-    ticker: 6762.T
-    name: TDK CORP.
-  -
-    ticker: 6770.T
-    name: ALPS ALPINE CO., LTD.
-  -
-    ticker: 6841.T
-    name: YOKOGAWA ELECTRIC CORP.
-  -
-    ticker: 6857.T
-    name: ADVANTEST CORP.
-  -
-    ticker: 6861.T
-    name: KEYENCE CORP.
-  -
-    ticker: 6902.T
-    name: DENSO CORP.
-  -
-    ticker: 6952.T
-    name: CASIO COMPUTER CO., LTD.
-  -
-    ticker: 6954.T
-    name: FANUC CORP.
-  -
-    ticker: 6963.T
-    name: ROHM CO., LTD.
-  -
-    ticker: 9984.T
-    name: SOFTBANK GROUP CORP.
-  -
-    ticker: 8306.T
-    name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-  -
-    ticker: 8316.T
-    name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-  -
-    ticker: 7974.T
-    name: NINTENDO CO., LTD.
-  -
-    ticker: 9983.T
-    name: FAST RETAILING CO., LTD.
-  -
-    ticker: 9432.T
-    name: NTT, INC.
-  -
-    ticker: 8411.T
-    name: MIZUHO FINANCIAL GROUP, INC.
-  -
-    ticker: 8766.T
-    name: TOKIO MARINE HOLDINGS, INC.
-  -
-    ticker: 8031.T
-    name: MITSUI & CO., LTD.
-  -
-    ticker: 2914.T
-    name: JAPAN TOBACCO INC.
-  -
-    ticker: 7267.T
-    name: HONDA MOTOR CO., LTD.
-  -
-    ticker: 4661.T
-    name: ORIENTAL LAND CO., LTD.
-  -
-    ticker: 6981.T
-    name: MURATA MANUFACTURING CO., LTD.
-  -
-    ticker: 6367.T
-    name: DAIKIN INDUSTRIES,LTD.
-  -
-    ticker: 8725.T
-    name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-  -
-    ticker: 3382.T
-    name: SEVEN & I HOLDINGS CO., LTD.
-  -
-    ticker: 6301.T
-    name: KOMATSU LTD.
-  -
-    ticker: 8267.T
-    name: AEON CO., LTD.
-  -
-    ticker: 8801.T
-    name: MITSUI FUDOSAN CO., LTD.
-  -
-    ticker: 2802.T
-    name: AJINOMOTO CO., INC.
-  -
-    ticker: 8802.T
-    name: MITSUBISHI ESTATE CO., LTD.
-  -
-    ticker: 5803.T
-    name: FUJIKURA LTD.
-  -
-    ticker: 7751.T
-    name: CANON INC.
-  -
-    ticker: 8308.T
-    name: RESONA HOLDINGS, INC.
-  -
-    ticker: 5802.T
-    name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-  -
-    ticker: 9613.T
-    name: NOMURA RESEARCH INSTITUTE, LTD.
-  -
-    ticker: 1925.T
-    name: DAIWA HOUSE INDUSTRY CO., LTD.
-  -
-    ticker: 7832.T
-    name: BANDAI NAMCO HOLDINGS INC.
-  -
-    ticker: 8830.T
-    name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-  -
-    ticker: 8309.T
-    name: SUMITOMO MITSUI TRUST GROUP, INC.
+conditions:
+  training_window:
+    start: 2014-04-24 09:00:00+09:00
+    end: 2014-12-30 09:00:00+09:00
+  evaluation_window:
+    start: 2015-01-05 09:00:00+09:00
+    end: 2015-12-30 09:00:00+09:00
 portfolio:
-  weights:
-    1332.T:
-      name: Nissui
-      weight: 0.109723
-    4061.T:
-      name: Denka
-      weight: 0.000000
-    5714.T:
-      name: DOWA Holdings
-      weight: 0.000000
-    7011.T:
-      name: Mitsubishi Heavy Industries
-      weight: 0.000000
-    8604.T:
-      name: NOMURA HOLDINGS, INC.
-      weight: 0.000000
-    4063.T:
-      name: Shin-Etsu Chemical
-      weight: 0.000000
-    7012.T:
-      name: Kawasaki Heavy Industries
-      weight: 0.068930
-    1605.T:
-      name: Inpex Corp
-      weight: 0.000000
-    4151.T:
-      name: KYOWA KIRIN CO., LTD.
-      weight: 0.000000
-    4502.T:
-      name: TAKEDA PHARMACEUTICAL CO., LTD.
-      weight: 0.000000
-    4503.T:
-      name: ASTELLAS PHARMA INC.
-      weight: 0.003218
-    4506.T:
-      name: SUMITOMO PHARMA CO., LTD.
-      weight: 0.000000
-    4507.T:
-      name: SHIONOGI & CO., LTD.
-      weight: 0.200000
-    4519.T:
-      name: CHUGAI PHARMACEUTICAL CO., LTD.
-      weight: 0.000000
-    4523.T:
-      name: EISAI CO., LTD.
-      weight: 0.000000
-    4568.T:
-      name: DAIICHI SANKYO CO., LTD.
-      weight: 0.000000
-    6479.T:
-      name: MINEBEA MITSUMI INC.
-      weight: 0.195499
-    6501.T:
-      name: HITACHI, LTD.
-      weight: 0.000000
-    6503.T:
-      name: MITSUBISHI ELECTRIC CORP.
-      weight: 0.000000
-    6504.T:
-      name: FUJI ELECTRIC CO., LTD.
-      weight: 0.000000
-    6506.T:
-      name: YASKAWA ELECTRIC CORP.
-      weight: 0.000000
-    6594.T:
-      name: NIDEC CORP.
-      weight: 0.000000
-    6645.T:
-      name: OMRON CORP.
-      weight: 0.000000
-    6674.T:
-      name: GS YUASA CORP.
-      weight: 0.000000
-    6701.T:
-      name: NEC CORP.
-      weight: 0.000000
-    6702.T:
-      name: FUJITSU LTD.
-      weight: 0.000000
-    6723.T:
-      name: RENESAS ELECTRONICS CORP.
-      weight: 0.000000
-    6724.T:
-      name: SEIKO EPSON CORP.
-      weight: 0.000628
-    6752.T:
-      name: PANASONIC HOLDINGS CORP.
-      weight: 0.000000
-    6753.T:
-      name: SHARP CORP.
-      weight: 0.000000
-    6758.T:
-      name: SONY GROUP CORP.
-      weight: 0.000000
-    6762.T:
-      name: TDK CORP.
-      weight: 0.000000
-    6770.T:
-      name: ALPS ALPINE CO., LTD.
-      weight: 0.118812
-    6841.T:
-      name: YOKOGAWA ELECTRIC CORP.
-      weight: 0.000000
-    6857.T:
-      name: ADVANTEST CORP.
-      weight: 0.000000
-    6861.T:
-      name: KEYENCE CORP.
-      weight: 0.000000
-    6902.T:
-      name: DENSO CORP.
-      weight: 0.000000
-    6952.T:
-      name: CASIO COMPUTER CO., LTD.
-      weight: 0.082731
-    6954.T:
-      name: FANUC CORP.
-      weight: 0.000000
-    6963.T:
-      name: ROHM CO., LTD.
-      weight: 0.000000
-    9984.T:
-      name: SOFTBANK GROUP CORP.
-      weight: 0.000000
-    8306.T:
-      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8316.T:
-      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-      weight: 0.000000
-    7974.T:
-      name: NINTENDO CO., LTD.
-      weight: 0.000000
-    9983.T:
-      name: FAST RETAILING CO., LTD.
-      weight: 0.000000
-    9432.T:
-      name: NTT, INC.
-      weight: 0.000000
-    8411.T:
-      name: MIZUHO FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8766.T:
-      name: TOKIO MARINE HOLDINGS, INC.
-      weight: 0.000000
-    8031.T:
-      name: MITSUI & CO., LTD.
-      weight: 0.000000
-    2914.T:
-      name: JAPAN TOBACCO INC.
-      weight: 0.000000
-    7267.T:
-      name: HONDA MOTOR CO., LTD.
-      weight: 0.000000
-    4661.T:
-      name: ORIENTAL LAND CO., LTD.
-      weight: 0.200000
-    6981.T:
-      name: MURATA MANUFACTURING CO., LTD.
-      weight: 0.000000
-    6367.T:
-      name: DAIKIN INDUSTRIES,LTD.
-      weight: 0.000000
-    8725.T:
-      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-      weight: 0.000000
-    3382.T:
-      name: SEVEN & I HOLDINGS CO., LTD.
-      weight: 0.000000
-    6301.T:
-      name: KOMATSU LTD.
-      weight: 0.000000
-    8267.T:
-      name: AEON CO., LTD.
-      weight: 0.000000
-    8801.T:
-      name: MITSUI FUDOSAN CO., LTD.
-      weight: 0.000000
-    2802.T:
-      name: AJINOMOTO CO., INC.
-      weight: 0.020459
-    8802.T:
-      name: MITSUBISHI ESTATE CO., LTD.
-      weight: 0.000000
-    5803.T:
-      name: FUJIKURA LTD.
-      weight: 0.000000
-    7751.T:
-      name: CANON INC.
-      weight: 0.000000
-    8308.T:
-      name: RESONA HOLDINGS, INC.
-      weight: 0.000000
-    5802.T:
-      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-      weight: 0.000000
-    9613.T:
-      name: NOMURA RESEARCH INSTITUTE, LTD.
-      weight: 0.000000
-    1925.T:
-      name: DAIWA HOUSE INDUSTRY CO., LTD.
-      weight: 0.000000
-    7832.T:
-      name: BANDAI NAMCO HOLDINGS INC.
-      weight: 0.000000
-    8830.T:
-      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-      weight: 0.000000
-    8309.T:
-      name: SUMITOMO MITSUI TRUST GROUP, INC.
-      weight: 0.000000
   risk_metrics:
     annual_return: 0.228915
     volatility: 0.255947
     sharpe_ratio: 0.894384
     max_drawdown: -0.217835
-  training_window:
-    start: 2014-04-24T09:00:00+09:00
-    end: 2014-12-30T09:00:00+09:00
-  evaluation_window:
-    start: 2015-01-05T09:00:00+09:00
-    end: 2015-12-30T09:00:00+09:00
+  allocations:
+    summary:
+      total_constituents: 70
+      invested_constituents: 10
+      zero_weight_constituents: 60
+      top3_weight: 0.595499
+      top10_weight: 1.000000
+    top_holdings:
+      -
+        rank: 1
+        ticker: 4507.T
+        name: SHIONOGI & CO., LTD.
+        weight: 0.200000
+      -
+        rank: 2
+        ticker: 4661.T
+        name: ORIENTAL LAND CO., LTD.
+        weight: 0.200000
+      -
+        rank: 3
+        ticker: 6479.T
+        name: MINEBEA MITSUMI INC.
+        weight: 0.195499
+      -
+        rank: 4
+        ticker: 6770.T
+        name: ALPS ALPINE CO., LTD.
+        weight: 0.118812
+      -
+        rank: 5
+        ticker: 1332.T
+        name: Nissui
+        weight: 0.109723
+      -
+        rank: 6
+        ticker: 6952.T
+        name: CASIO COMPUTER CO., LTD.
+        weight: 0.082731
+      -
+        rank: 7
+        ticker: 7012.T
+        name: Kawasaki Heavy Industries
+        weight: 0.068930
+      -
+        rank: 8
+        ticker: 2802.T
+        name: AJINOMOTO CO., INC.
+        weight: 0.020459
+      -
+        rank: 9
+        ticker: 4503.T
+        name: ASTELLAS PHARMA INC.
+        weight: 0.003218
+      -
+        rank: 10
+        ticker: 6724.T
+        name: SEIKO EPSON CORP.
+        weight: 0.000628
+    smallest_active_weights:
+      -
+        ticker: 6724.T
+        name: SEIKO EPSON CORP.
+        weight: 0.000628
+      -
+        ticker: 4503.T
+        name: ASTELLAS PHARMA INC.
+        weight: 0.003218
+      -
+        ticker: 2802.T
+        name: AJINOMOTO CO., INC.
+        weight: 0.020459
+      -
+        ticker: 7012.T
+        name: Kawasaki Heavy Industries
+        weight: 0.068930
+      -
+        ticker: 6952.T
+        name: CASIO COMPUTER CO., LTD.
+        weight: 0.082731
+    weight_buckets:
+      -
+        label: 10%以上
+        count: 5
+        weight_share: 0.824034
+        sample:
+          -
+            ticker: 4507.T
+            name: SHIONOGI & CO., LTD.
+            weight: 0.200000
+          -
+            ticker: 4661.T
+            name: ORIENTAL LAND CO., LTD.
+            weight: 0.200000
+          -
+            ticker: 6479.T
+            name: MINEBEA MITSUMI INC.
+            weight: 0.195499
+          -
+            ticker: 6770.T
+            name: ALPS ALPINE CO., LTD.
+            weight: 0.118812
+          -
+            ticker: 1332.T
+            name: Nissui
+            weight: 0.109723
+      -
+        label: 5%-10%
+        count: 2
+        weight_share: 0.151661
+        sample:
+          -
+            ticker: 6952.T
+            name: CASIO COMPUTER CO., LTD.
+            weight: 0.082731
+          -
+            ticker: 7012.T
+            name: Kawasaki Heavy Industries
+            weight: 0.068930
+      -
+        label: 1%-5%
+        count: 1
+        weight_share: 0.020459
+        sample:
+          -
+            ticker: 2802.T
+            name: AJINOMOTO CO., INC.
+            weight: 0.020459
+      -
+        label: 1%未満
+        count: 62
+        weight_share: 0.003846
+        sample:
+          -
+            ticker: 4503.T
+            name: ASTELLAS PHARMA INC.
+            weight: 0.003218
+          -
+            ticker: 6724.T
+            name: SEIKO EPSON CORP.
+            weight: 0.000628
+          -
+            ticker: 4061.T
+            name: Denka
+            weight: 0.000000
+          -
+            ticker: 5714.T
+            name: DOWA Holdings
+            weight: 0.000000
+          -
+            ticker: 7011.T
+            name: Mitsubishi Heavy Industries
+            weight: 0.000000
+    by_ticker:
+      1332.T:
+        name: Nissui
+        weight: 0.109723
+      1605.T:
+        name: Inpex Corp
+        weight: 0.000000
+      1925.T:
+        name: DAIWA HOUSE INDUSTRY CO., LTD.
+        weight: 0.000000
+      2802.T:
+        name: AJINOMOTO CO., INC.
+        weight: 0.020459
+      2914.T:
+        name: JAPAN TOBACCO INC.
+        weight: 0.000000
+      3382.T:
+        name: SEVEN & I HOLDINGS CO., LTD.
+        weight: 0.000000
+      4061.T:
+        name: Denka
+        weight: 0.000000
+      4063.T:
+        name: Shin-Etsu Chemical
+        weight: 0.000000
+      4151.T:
+        name: KYOWA KIRIN CO., LTD.
+        weight: 0.000000
+      4502.T:
+        name: TAKEDA PHARMACEUTICAL CO., LTD.
+        weight: 0.000000
+      4503.T:
+        name: ASTELLAS PHARMA INC.
+        weight: 0.003218
+      4506.T:
+        name: SUMITOMO PHARMA CO., LTD.
+        weight: 0.000000
+      4507.T:
+        name: SHIONOGI & CO., LTD.
+        weight: 0.200000
+      4519.T:
+        name: CHUGAI PHARMACEUTICAL CO., LTD.
+        weight: 0.000000
+      4523.T:
+        name: EISAI CO., LTD.
+        weight: 0.000000
+      4568.T:
+        name: DAIICHI SANKYO CO., LTD.
+        weight: 0.000000
+      4661.T:
+        name: ORIENTAL LAND CO., LTD.
+        weight: 0.200000
+      5714.T:
+        name: DOWA Holdings
+        weight: 0.000000
+      5802.T:
+        name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+        weight: 0.000000
+      5803.T:
+        name: FUJIKURA LTD.
+        weight: 0.000000
+      6301.T:
+        name: KOMATSU LTD.
+        weight: 0.000000
+      6367.T:
+        name: DAIKIN INDUSTRIES,LTD.
+        weight: 0.000000
+      6479.T:
+        name: MINEBEA MITSUMI INC.
+        weight: 0.195499
+      6501.T:
+        name: HITACHI, LTD.
+        weight: 0.000000
+      6503.T:
+        name: MITSUBISHI ELECTRIC CORP.
+        weight: 0.000000
+      6504.T:
+        name: FUJI ELECTRIC CO., LTD.
+        weight: 0.000000
+      6506.T:
+        name: YASKAWA ELECTRIC CORP.
+        weight: 0.000000
+      6594.T:
+        name: NIDEC CORP.
+        weight: 0.000000
+      6645.T:
+        name: OMRON CORP.
+        weight: 0.000000
+      6674.T:
+        name: GS YUASA CORP.
+        weight: 0.000000
+      6701.T:
+        name: NEC CORP.
+        weight: 0.000000
+      6702.T:
+        name: FUJITSU LTD.
+        weight: 0.000000
+      6723.T:
+        name: RENESAS ELECTRONICS CORP.
+        weight: 0.000000
+      6724.T:
+        name: SEIKO EPSON CORP.
+        weight: 0.000628
+      6752.T:
+        name: PANASONIC HOLDINGS CORP.
+        weight: 0.000000
+      6753.T:
+        name: SHARP CORP.
+        weight: 0.000000
+      6758.T:
+        name: SONY GROUP CORP.
+        weight: 0.000000
+      6762.T:
+        name: TDK CORP.
+        weight: 0.000000
+      6770.T:
+        name: ALPS ALPINE CO., LTD.
+        weight: 0.118812
+      6841.T:
+        name: YOKOGAWA ELECTRIC CORP.
+        weight: 0.000000
+      6857.T:
+        name: ADVANTEST CORP.
+        weight: 0.000000
+      6861.T:
+        name: KEYENCE CORP.
+        weight: 0.000000
+      6902.T:
+        name: DENSO CORP.
+        weight: 0.000000
+      6952.T:
+        name: CASIO COMPUTER CO., LTD.
+        weight: 0.082731
+      6954.T:
+        name: FANUC CORP.
+        weight: 0.000000
+      6963.T:
+        name: ROHM CO., LTD.
+        weight: 0.000000
+      6981.T:
+        name: MURATA MANUFACTURING CO., LTD.
+        weight: 0.000000
+      7011.T:
+        name: Mitsubishi Heavy Industries
+        weight: 0.000000
+      7012.T:
+        name: Kawasaki Heavy Industries
+        weight: 0.068930
+      7267.T:
+        name: HONDA MOTOR CO., LTD.
+        weight: 0.000000
+      7751.T:
+        name: CANON INC.
+        weight: 0.000000
+      7832.T:
+        name: BANDAI NAMCO HOLDINGS INC.
+        weight: 0.000000
+      7974.T:
+        name: NINTENDO CO., LTD.
+        weight: 0.000000
+      8031.T:
+        name: MITSUI & CO., LTD.
+        weight: 0.000000
+      8267.T:
+        name: AEON CO., LTD.
+        weight: 0.000000
+      8306.T:
+        name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8308.T:
+        name: RESONA HOLDINGS, INC.
+        weight: 0.000000
+      8309.T:
+        name: SUMITOMO MITSUI TRUST GROUP, INC.
+        weight: 0.000000
+      8316.T:
+        name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8411.T:
+        name: MIZUHO FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8604.T:
+        name: NOMURA HOLDINGS, INC.
+        weight: 0.000000
+      8725.T:
+        name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+        weight: 0.000000
+      8766.T:
+        name: TOKIO MARINE HOLDINGS, INC.
+        weight: 0.000000
+      8801.T:
+        name: MITSUI FUDOSAN CO., LTD.
+        weight: 0.000000
+      8802.T:
+        name: MITSUBISHI ESTATE CO., LTD.
+        weight: 0.000000
+      8830.T:
+        name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+        weight: 0.000000
+      9432.T:
+        name: NTT, INC.
+        weight: 0.000000
+      9613.T:
+        name: NOMURA RESEARCH INSTITUTE, LTD.
+        weight: 0.000000
+      9983.T:
+        name: FAST RETAILING CO., LTD.
+        weight: 0.000000
+      9984.T:
+        name: SOFTBANK GROUP CORP.
+        weight: 0.000000
+universe:
+  count: 70
+  members:
+    -
+      ticker: 1332.T
+      name: Nissui
+    -
+      ticker: 1605.T
+      name: Inpex Corp
+    -
+      ticker: 1925.T
+      name: DAIWA HOUSE INDUSTRY CO., LTD.
+    -
+      ticker: 2802.T
+      name: AJINOMOTO CO., INC.
+    -
+      ticker: 2914.T
+      name: JAPAN TOBACCO INC.
+    -
+      ticker: 3382.T
+      name: SEVEN & I HOLDINGS CO., LTD.
+    -
+      ticker: 4061.T
+      name: Denka
+    -
+      ticker: 4063.T
+      name: Shin-Etsu Chemical
+    -
+      ticker: 4151.T
+      name: KYOWA KIRIN CO., LTD.
+    -
+      ticker: 4502.T
+      name: TAKEDA PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4503.T
+      name: ASTELLAS PHARMA INC.
+    -
+      ticker: 4506.T
+      name: SUMITOMO PHARMA CO., LTD.
+    -
+      ticker: 4507.T
+      name: SHIONOGI & CO., LTD.
+    -
+      ticker: 4519.T
+      name: CHUGAI PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4523.T
+      name: EISAI CO., LTD.
+    -
+      ticker: 4568.T
+      name: DAIICHI SANKYO CO., LTD.
+    -
+      ticker: 4661.T
+      name: ORIENTAL LAND CO., LTD.
+    -
+      ticker: 5714.T
+      name: DOWA Holdings
+    -
+      ticker: 5802.T
+      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+    -
+      ticker: 5803.T
+      name: FUJIKURA LTD.
+    -
+      ticker: 6301.T
+      name: KOMATSU LTD.
+    -
+      ticker: 6367.T
+      name: DAIKIN INDUSTRIES,LTD.
+    -
+      ticker: 6479.T
+      name: MINEBEA MITSUMI INC.
+    -
+      ticker: 6501.T
+      name: HITACHI, LTD.
+    -
+      ticker: 6503.T
+      name: MITSUBISHI ELECTRIC CORP.
+    -
+      ticker: 6504.T
+      name: FUJI ELECTRIC CO., LTD.
+    -
+      ticker: 6506.T
+      name: YASKAWA ELECTRIC CORP.
+    -
+      ticker: 6594.T
+      name: NIDEC CORP.
+    -
+      ticker: 6645.T
+      name: OMRON CORP.
+    -
+      ticker: 6674.T
+      name: GS YUASA CORP.
+    -
+      ticker: 6701.T
+      name: NEC CORP.
+    -
+      ticker: 6702.T
+      name: FUJITSU LTD.
+    -
+      ticker: 6723.T
+      name: RENESAS ELECTRONICS CORP.
+    -
+      ticker: 6724.T
+      name: SEIKO EPSON CORP.
+    -
+      ticker: 6752.T
+      name: PANASONIC HOLDINGS CORP.
+    -
+      ticker: 6753.T
+      name: SHARP CORP.
+    -
+      ticker: 6758.T
+      name: SONY GROUP CORP.
+    -
+      ticker: 6762.T
+      name: TDK CORP.
+    -
+      ticker: 6770.T
+      name: ALPS ALPINE CO., LTD.
+    -
+      ticker: 6841.T
+      name: YOKOGAWA ELECTRIC CORP.
+    -
+      ticker: 6857.T
+      name: ADVANTEST CORP.
+    -
+      ticker: 6861.T
+      name: KEYENCE CORP.
+    -
+      ticker: 6902.T
+      name: DENSO CORP.
+    -
+      ticker: 6952.T
+      name: CASIO COMPUTER CO., LTD.
+    -
+      ticker: 6954.T
+      name: FANUC CORP.
+    -
+      ticker: 6963.T
+      name: ROHM CO., LTD.
+    -
+      ticker: 6981.T
+      name: MURATA MANUFACTURING CO., LTD.
+    -
+      ticker: 7011.T
+      name: Mitsubishi Heavy Industries
+    -
+      ticker: 7012.T
+      name: Kawasaki Heavy Industries
+    -
+      ticker: 7267.T
+      name: HONDA MOTOR CO., LTD.
+    -
+      ticker: 7751.T
+      name: CANON INC.
+    -
+      ticker: 7832.T
+      name: BANDAI NAMCO HOLDINGS INC.
+    -
+      ticker: 7974.T
+      name: NINTENDO CO., LTD.
+    -
+      ticker: 8031.T
+      name: MITSUI & CO., LTD.
+    -
+      ticker: 8267.T
+      name: AEON CO., LTD.
+    -
+      ticker: 8306.T
+      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+    -
+      ticker: 8308.T
+      name: RESONA HOLDINGS, INC.
+    -
+      ticker: 8309.T
+      name: SUMITOMO MITSUI TRUST GROUP, INC.
+    -
+      ticker: 8316.T
+      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+    -
+      ticker: 8411.T
+      name: MIZUHO FINANCIAL GROUP, INC.
+    -
+      ticker: 8604.T
+      name: NOMURA HOLDINGS, INC.
+    -
+      ticker: 8725.T
+      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+    -
+      ticker: 8766.T
+      name: TOKIO MARINE HOLDINGS, INC.
+    -
+      ticker: 8801.T
+      name: MITSUI FUDOSAN CO., LTD.
+    -
+      ticker: 8802.T
+      name: MITSUBISHI ESTATE CO., LTD.
+    -
+      ticker: 8830.T
+      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+    -
+      ticker: 9432.T
+      name: NTT, INC.
+    -
+      ticker: 9613.T
+      name: NOMURA RESEARCH INSTITUTE, LTD.
+    -
+      ticker: 9983.T
+      name: FAST RETAILING CO., LTD.
+    -
+      ticker: 9984.T
+      name: SOFTBANK GROUP CORP.

--- a/reports/portfolio/2016.yaml
+++ b/reports/portfolio/2016.yaml
@@ -1,437 +1,589 @@
+year: 2016
 period:
   start: 2016-01-01
   end: 2016-12-31
-universe:
-  -
-    ticker: 1332.T
-    name: Nissui
-  -
-    ticker: 4061.T
-    name: Denka
-  -
-    ticker: 5714.T
-    name: DOWA Holdings
-  -
-    ticker: 7011.T
-    name: Mitsubishi Heavy Industries
-  -
-    ticker: 8604.T
-    name: NOMURA HOLDINGS, INC.
-  -
-    ticker: 4063.T
-    name: Shin-Etsu Chemical
-  -
-    ticker: 7012.T
-    name: Kawasaki Heavy Industries
-  -
-    ticker: 1605.T
-    name: Inpex Corp
-  -
-    ticker: 4151.T
-    name: KYOWA KIRIN CO., LTD.
-  -
-    ticker: 4502.T
-    name: TAKEDA PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4503.T
-    name: ASTELLAS PHARMA INC.
-  -
-    ticker: 4506.T
-    name: SUMITOMO PHARMA CO., LTD.
-  -
-    ticker: 4507.T
-    name: SHIONOGI & CO., LTD.
-  -
-    ticker: 4519.T
-    name: CHUGAI PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4523.T
-    name: EISAI CO., LTD.
-  -
-    ticker: 4568.T
-    name: DAIICHI SANKYO CO., LTD.
-  -
-    ticker: 6479.T
-    name: MINEBEA MITSUMI INC.
-  -
-    ticker: 6501.T
-    name: HITACHI, LTD.
-  -
-    ticker: 6503.T
-    name: MITSUBISHI ELECTRIC CORP.
-  -
-    ticker: 6504.T
-    name: FUJI ELECTRIC CO., LTD.
-  -
-    ticker: 6506.T
-    name: YASKAWA ELECTRIC CORP.
-  -
-    ticker: 6594.T
-    name: NIDEC CORP.
-  -
-    ticker: 6645.T
-    name: OMRON CORP.
-  -
-    ticker: 6674.T
-    name: GS YUASA CORP.
-  -
-    ticker: 6701.T
-    name: NEC CORP.
-  -
-    ticker: 6702.T
-    name: FUJITSU LTD.
-  -
-    ticker: 6723.T
-    name: RENESAS ELECTRONICS CORP.
-  -
-    ticker: 6724.T
-    name: SEIKO EPSON CORP.
-  -
-    ticker: 6752.T
-    name: PANASONIC HOLDINGS CORP.
-  -
-    ticker: 6753.T
-    name: SHARP CORP.
-  -
-    ticker: 6758.T
-    name: SONY GROUP CORP.
-  -
-    ticker: 6762.T
-    name: TDK CORP.
-  -
-    ticker: 6770.T
-    name: ALPS ALPINE CO., LTD.
-  -
-    ticker: 6841.T
-    name: YOKOGAWA ELECTRIC CORP.
-  -
-    ticker: 6857.T
-    name: ADVANTEST CORP.
-  -
-    ticker: 6861.T
-    name: KEYENCE CORP.
-  -
-    ticker: 6902.T
-    name: DENSO CORP.
-  -
-    ticker: 6952.T
-    name: CASIO COMPUTER CO., LTD.
-  -
-    ticker: 6954.T
-    name: FANUC CORP.
-  -
-    ticker: 6963.T
-    name: ROHM CO., LTD.
-  -
-    ticker: 9984.T
-    name: SOFTBANK GROUP CORP.
-  -
-    ticker: 8306.T
-    name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-  -
-    ticker: 8316.T
-    name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-  -
-    ticker: 7974.T
-    name: NINTENDO CO., LTD.
-  -
-    ticker: 9983.T
-    name: FAST RETAILING CO., LTD.
-  -
-    ticker: 9432.T
-    name: NTT, INC.
-  -
-    ticker: 8411.T
-    name: MIZUHO FINANCIAL GROUP, INC.
-  -
-    ticker: 8766.T
-    name: TOKIO MARINE HOLDINGS, INC.
-  -
-    ticker: 8031.T
-    name: MITSUI & CO., LTD.
-  -
-    ticker: 2914.T
-    name: JAPAN TOBACCO INC.
-  -
-    ticker: 7267.T
-    name: HONDA MOTOR CO., LTD.
-  -
-    ticker: 4661.T
-    name: ORIENTAL LAND CO., LTD.
-  -
-    ticker: 6981.T
-    name: MURATA MANUFACTURING CO., LTD.
-  -
-    ticker: 6367.T
-    name: DAIKIN INDUSTRIES,LTD.
-  -
-    ticker: 8725.T
-    name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-  -
-    ticker: 3382.T
-    name: SEVEN & I HOLDINGS CO., LTD.
-  -
-    ticker: 6301.T
-    name: KOMATSU LTD.
-  -
-    ticker: 8267.T
-    name: AEON CO., LTD.
-  -
-    ticker: 8801.T
-    name: MITSUI FUDOSAN CO., LTD.
-  -
-    ticker: 2802.T
-    name: AJINOMOTO CO., INC.
-  -
-    ticker: 8802.T
-    name: MITSUBISHI ESTATE CO., LTD.
-  -
-    ticker: 5803.T
-    name: FUJIKURA LTD.
-  -
-    ticker: 7751.T
-    name: CANON INC.
-  -
-    ticker: 8308.T
-    name: RESONA HOLDINGS, INC.
-  -
-    ticker: 5802.T
-    name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-  -
-    ticker: 9613.T
-    name: NOMURA RESEARCH INSTITUTE, LTD.
-  -
-    ticker: 1925.T
-    name: DAIWA HOUSE INDUSTRY CO., LTD.
-  -
-    ticker: 7832.T
-    name: BANDAI NAMCO HOLDINGS INC.
-  -
-    ticker: 8830.T
-    name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-  -
-    ticker: 8309.T
-    name: SUMITOMO MITSUI TRUST GROUP, INC.
+conditions:
+  training_window:
+    start: 2015-04-24 09:00:00+09:00
+    end: 2015-12-30 09:00:00+09:00
+  evaluation_window:
+    start: 2016-01-04 09:00:00+09:00
+    end: 2016-12-30 09:00:00+09:00
 portfolio:
-  weights:
-    1332.T:
-      name: Nissui
-      weight: 0.200000
-    4061.T:
-      name: Denka
-      weight: 0.000000
-    5714.T:
-      name: DOWA Holdings
-      weight: 0.000000
-    7011.T:
-      name: Mitsubishi Heavy Industries
-      weight: 0.000000
-    8604.T:
-      name: NOMURA HOLDINGS, INC.
-      weight: 0.000000
-    4063.T:
-      name: Shin-Etsu Chemical
-      weight: 0.000000
-    7012.T:
-      name: Kawasaki Heavy Industries
-      weight: 0.000000
-    1605.T:
-      name: Inpex Corp
-      weight: 0.000000
-    4151.T:
-      name: KYOWA KIRIN CO., LTD.
-      weight: 0.000000
-    4502.T:
-      name: TAKEDA PHARMACEUTICAL CO., LTD.
-      weight: 0.000000
-    4503.T:
-      name: ASTELLAS PHARMA INC.
-      weight: 0.000000
-    4506.T:
-      name: SUMITOMO PHARMA CO., LTD.
-      weight: 0.000000
-    4507.T:
-      name: SHIONOGI & CO., LTD.
-      weight: 0.102977
-    4519.T:
-      name: CHUGAI PHARMACEUTICAL CO., LTD.
-      weight: 0.000000
-    4523.T:
-      name: EISAI CO., LTD.
-      weight: 0.000000
-    4568.T:
-      name: DAIICHI SANKYO CO., LTD.
-      weight: 0.027348
-    6479.T:
-      name: MINEBEA MITSUMI INC.
-      weight: 0.000000
-    6501.T:
-      name: HITACHI, LTD.
-      weight: 0.000000
-    6503.T:
-      name: MITSUBISHI ELECTRIC CORP.
-      weight: 0.000000
-    6504.T:
-      name: FUJI ELECTRIC CO., LTD.
-      weight: 0.000000
-    6506.T:
-      name: YASKAWA ELECTRIC CORP.
-      weight: 0.000000
-    6594.T:
-      name: NIDEC CORP.
-      weight: 0.000000
-    6645.T:
-      name: OMRON CORP.
-      weight: 0.000000
-    6674.T:
-      name: GS YUASA CORP.
-      weight: 0.000000
-    6701.T:
-      name: NEC CORP.
-      weight: 0.000000
-    6702.T:
-      name: FUJITSU LTD.
-      weight: 0.000000
-    6723.T:
-      name: RENESAS ELECTRONICS CORP.
-      weight: 0.000000
-    6724.T:
-      name: SEIKO EPSON CORP.
-      weight: 0.000000
-    6752.T:
-      name: PANASONIC HOLDINGS CORP.
-      weight: 0.000000
-    6753.T:
-      name: SHARP CORP.
-      weight: 0.000000
-    6758.T:
-      name: SONY GROUP CORP.
-      weight: 0.000000
-    6762.T:
-      name: TDK CORP.
-      weight: 0.000000
-    6770.T:
-      name: ALPS ALPINE CO., LTD.
-      weight: 0.000000
-    6841.T:
-      name: YOKOGAWA ELECTRIC CORP.
-      weight: 0.000000
-    6857.T:
-      name: ADVANTEST CORP.
-      weight: 0.000000
-    6861.T:
-      name: KEYENCE CORP.
-      weight: 0.000000
-    6902.T:
-      name: DENSO CORP.
-      weight: 0.000000
-    6952.T:
-      name: CASIO COMPUTER CO., LTD.
-      weight: 0.061462
-    6954.T:
-      name: FANUC CORP.
-      weight: 0.000000
-    6963.T:
-      name: ROHM CO., LTD.
-      weight: 0.000000
-    9984.T:
-      name: SOFTBANK GROUP CORP.
-      weight: 0.000000
-    8306.T:
-      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8316.T:
-      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-      weight: 0.000000
-    7974.T:
-      name: NINTENDO CO., LTD.
-      weight: 0.000000
-    9983.T:
-      name: FAST RETAILING CO., LTD.
-      weight: 0.000000
-    9432.T:
-      name: NTT, INC.
-      weight: 0.200000
-    8411.T:
-      name: MIZUHO FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8766.T:
-      name: TOKIO MARINE HOLDINGS, INC.
-      weight: 0.000000
-    8031.T:
-      name: MITSUI & CO., LTD.
-      weight: 0.000000
-    2914.T:
-      name: JAPAN TOBACCO INC.
-      weight: 0.000000
-    7267.T:
-      name: HONDA MOTOR CO., LTD.
-      weight: 0.000000
-    4661.T:
-      name: ORIENTAL LAND CO., LTD.
-      weight: 0.000000
-    6981.T:
-      name: MURATA MANUFACTURING CO., LTD.
-      weight: 0.000000
-    6367.T:
-      name: DAIKIN INDUSTRIES,LTD.
-      weight: 0.000000
-    8725.T:
-      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-      weight: 0.000000
-    3382.T:
-      name: SEVEN & I HOLDINGS CO., LTD.
-      weight: 0.000000
-    6301.T:
-      name: KOMATSU LTD.
-      weight: 0.000000
-    8267.T:
-      name: AEON CO., LTD.
-      weight: 0.200000
-    8801.T:
-      name: MITSUI FUDOSAN CO., LTD.
-      weight: 0.000000
-    2802.T:
-      name: AJINOMOTO CO., INC.
-      weight: 0.000000
-    8802.T:
-      name: MITSUBISHI ESTATE CO., LTD.
-      weight: 0.000000
-    5803.T:
-      name: FUJIKURA LTD.
-      weight: 0.008213
-    7751.T:
-      name: CANON INC.
-      weight: 0.000000
-    8308.T:
-      name: RESONA HOLDINGS, INC.
-      weight: 0.000000
-    5802.T:
-      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-      weight: 0.000000
-    9613.T:
-      name: NOMURA RESEARCH INSTITUTE, LTD.
-      weight: 0.000000
-    1925.T:
-      name: DAIWA HOUSE INDUSTRY CO., LTD.
-      weight: 0.200000
-    7832.T:
-      name: BANDAI NAMCO HOLDINGS INC.
-      weight: 0.000000
-    8830.T:
-      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-      weight: 0.000000
-    8309.T:
-      name: SUMITOMO MITSUI TRUST GROUP, INC.
-      weight: 0.000000
   risk_metrics:
     annual_return: -0.049642
     volatility: 0.262326
     sharpe_ratio: -0.189237
     max_drawdown: -0.212193
-  training_window:
-    start: 2015-04-24T09:00:00+09:00
-    end: 2015-12-30T09:00:00+09:00
-  evaluation_window:
-    start: 2016-01-04T09:00:00+09:00
-    end: 2016-12-30T09:00:00+09:00
+  allocations:
+    summary:
+      total_constituents: 70
+      invested_constituents: 8
+      zero_weight_constituents: 62
+      top3_weight: 0.600000
+      top10_weight: 1.000000
+    top_holdings:
+      -
+        rank: 1
+        ticker: 1332.T
+        name: Nissui
+        weight: 0.200000
+      -
+        rank: 2
+        ticker: 9432.T
+        name: NTT, INC.
+        weight: 0.200000
+      -
+        rank: 3
+        ticker: 8267.T
+        name: AEON CO., LTD.
+        weight: 0.200000
+      -
+        rank: 4
+        ticker: 1925.T
+        name: DAIWA HOUSE INDUSTRY CO., LTD.
+        weight: 0.200000
+      -
+        rank: 5
+        ticker: 4507.T
+        name: SHIONOGI & CO., LTD.
+        weight: 0.102977
+      -
+        rank: 6
+        ticker: 6952.T
+        name: CASIO COMPUTER CO., LTD.
+        weight: 0.061462
+      -
+        rank: 7
+        ticker: 4568.T
+        name: DAIICHI SANKYO CO., LTD.
+        weight: 0.027348
+      -
+        rank: 8
+        ticker: 5803.T
+        name: FUJIKURA LTD.
+        weight: 0.008213
+      -
+        rank: 9
+        ticker: 4061.T
+        name: Denka
+        weight: 0.000000
+      -
+        rank: 10
+        ticker: 5714.T
+        name: DOWA Holdings
+        weight: 0.000000
+    smallest_active_weights:
+      -
+        ticker: 5803.T
+        name: FUJIKURA LTD.
+        weight: 0.008213
+      -
+        ticker: 4568.T
+        name: DAIICHI SANKYO CO., LTD.
+        weight: 0.027348
+      -
+        ticker: 6952.T
+        name: CASIO COMPUTER CO., LTD.
+        weight: 0.061462
+      -
+        ticker: 4507.T
+        name: SHIONOGI & CO., LTD.
+        weight: 0.102977
+      -
+        ticker: 1332.T
+        name: Nissui
+        weight: 0.200000
+    weight_buckets:
+      -
+        label: 10%以上
+        count: 5
+        weight_share: 0.902977
+        sample:
+          -
+            ticker: 1332.T
+            name: Nissui
+            weight: 0.200000
+          -
+            ticker: 9432.T
+            name: NTT, INC.
+            weight: 0.200000
+          -
+            ticker: 8267.T
+            name: AEON CO., LTD.
+            weight: 0.200000
+          -
+            ticker: 1925.T
+            name: DAIWA HOUSE INDUSTRY CO., LTD.
+            weight: 0.200000
+          -
+            ticker: 4507.T
+            name: SHIONOGI & CO., LTD.
+            weight: 0.102977
+      -
+        label: 5%-10%
+        count: 1
+        weight_share: 0.061462
+        sample:
+          -
+            ticker: 6952.T
+            name: CASIO COMPUTER CO., LTD.
+            weight: 0.061462
+      -
+        label: 1%-5%
+        count: 1
+        weight_share: 0.027348
+        sample:
+          -
+            ticker: 4568.T
+            name: DAIICHI SANKYO CO., LTD.
+            weight: 0.027348
+      -
+        label: 1%未満
+        count: 63
+        weight_share: 0.008213
+        sample:
+          -
+            ticker: 5803.T
+            name: FUJIKURA LTD.
+            weight: 0.008213
+          -
+            ticker: 4061.T
+            name: Denka
+            weight: 0.000000
+          -
+            ticker: 5714.T
+            name: DOWA Holdings
+            weight: 0.000000
+          -
+            ticker: 7011.T
+            name: Mitsubishi Heavy Industries
+            weight: 0.000000
+          -
+            ticker: 8604.T
+            name: NOMURA HOLDINGS, INC.
+            weight: 0.000000
+    by_ticker:
+      1332.T:
+        name: Nissui
+        weight: 0.200000
+      1605.T:
+        name: Inpex Corp
+        weight: 0.000000
+      1925.T:
+        name: DAIWA HOUSE INDUSTRY CO., LTD.
+        weight: 0.200000
+      2802.T:
+        name: AJINOMOTO CO., INC.
+        weight: 0.000000
+      2914.T:
+        name: JAPAN TOBACCO INC.
+        weight: 0.000000
+      3382.T:
+        name: SEVEN & I HOLDINGS CO., LTD.
+        weight: 0.000000
+      4061.T:
+        name: Denka
+        weight: 0.000000
+      4063.T:
+        name: Shin-Etsu Chemical
+        weight: 0.000000
+      4151.T:
+        name: KYOWA KIRIN CO., LTD.
+        weight: 0.000000
+      4502.T:
+        name: TAKEDA PHARMACEUTICAL CO., LTD.
+        weight: 0.000000
+      4503.T:
+        name: ASTELLAS PHARMA INC.
+        weight: 0.000000
+      4506.T:
+        name: SUMITOMO PHARMA CO., LTD.
+        weight: 0.000000
+      4507.T:
+        name: SHIONOGI & CO., LTD.
+        weight: 0.102977
+      4519.T:
+        name: CHUGAI PHARMACEUTICAL CO., LTD.
+        weight: 0.000000
+      4523.T:
+        name: EISAI CO., LTD.
+        weight: 0.000000
+      4568.T:
+        name: DAIICHI SANKYO CO., LTD.
+        weight: 0.027348
+      4661.T:
+        name: ORIENTAL LAND CO., LTD.
+        weight: 0.000000
+      5714.T:
+        name: DOWA Holdings
+        weight: 0.000000
+      5802.T:
+        name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+        weight: 0.000000
+      5803.T:
+        name: FUJIKURA LTD.
+        weight: 0.008213
+      6301.T:
+        name: KOMATSU LTD.
+        weight: 0.000000
+      6367.T:
+        name: DAIKIN INDUSTRIES,LTD.
+        weight: 0.000000
+      6479.T:
+        name: MINEBEA MITSUMI INC.
+        weight: 0.000000
+      6501.T:
+        name: HITACHI, LTD.
+        weight: 0.000000
+      6503.T:
+        name: MITSUBISHI ELECTRIC CORP.
+        weight: 0.000000
+      6504.T:
+        name: FUJI ELECTRIC CO., LTD.
+        weight: 0.000000
+      6506.T:
+        name: YASKAWA ELECTRIC CORP.
+        weight: 0.000000
+      6594.T:
+        name: NIDEC CORP.
+        weight: 0.000000
+      6645.T:
+        name: OMRON CORP.
+        weight: 0.000000
+      6674.T:
+        name: GS YUASA CORP.
+        weight: 0.000000
+      6701.T:
+        name: NEC CORP.
+        weight: 0.000000
+      6702.T:
+        name: FUJITSU LTD.
+        weight: 0.000000
+      6723.T:
+        name: RENESAS ELECTRONICS CORP.
+        weight: 0.000000
+      6724.T:
+        name: SEIKO EPSON CORP.
+        weight: 0.000000
+      6752.T:
+        name: PANASONIC HOLDINGS CORP.
+        weight: 0.000000
+      6753.T:
+        name: SHARP CORP.
+        weight: 0.000000
+      6758.T:
+        name: SONY GROUP CORP.
+        weight: 0.000000
+      6762.T:
+        name: TDK CORP.
+        weight: 0.000000
+      6770.T:
+        name: ALPS ALPINE CO., LTD.
+        weight: 0.000000
+      6841.T:
+        name: YOKOGAWA ELECTRIC CORP.
+        weight: 0.000000
+      6857.T:
+        name: ADVANTEST CORP.
+        weight: 0.000000
+      6861.T:
+        name: KEYENCE CORP.
+        weight: 0.000000
+      6902.T:
+        name: DENSO CORP.
+        weight: 0.000000
+      6952.T:
+        name: CASIO COMPUTER CO., LTD.
+        weight: 0.061462
+      6954.T:
+        name: FANUC CORP.
+        weight: 0.000000
+      6963.T:
+        name: ROHM CO., LTD.
+        weight: 0.000000
+      6981.T:
+        name: MURATA MANUFACTURING CO., LTD.
+        weight: 0.000000
+      7011.T:
+        name: Mitsubishi Heavy Industries
+        weight: 0.000000
+      7012.T:
+        name: Kawasaki Heavy Industries
+        weight: 0.000000
+      7267.T:
+        name: HONDA MOTOR CO., LTD.
+        weight: 0.000000
+      7751.T:
+        name: CANON INC.
+        weight: 0.000000
+      7832.T:
+        name: BANDAI NAMCO HOLDINGS INC.
+        weight: 0.000000
+      7974.T:
+        name: NINTENDO CO., LTD.
+        weight: 0.000000
+      8031.T:
+        name: MITSUI & CO., LTD.
+        weight: 0.000000
+      8267.T:
+        name: AEON CO., LTD.
+        weight: 0.200000
+      8306.T:
+        name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8308.T:
+        name: RESONA HOLDINGS, INC.
+        weight: 0.000000
+      8309.T:
+        name: SUMITOMO MITSUI TRUST GROUP, INC.
+        weight: 0.000000
+      8316.T:
+        name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8411.T:
+        name: MIZUHO FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8604.T:
+        name: NOMURA HOLDINGS, INC.
+        weight: 0.000000
+      8725.T:
+        name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+        weight: 0.000000
+      8766.T:
+        name: TOKIO MARINE HOLDINGS, INC.
+        weight: 0.000000
+      8801.T:
+        name: MITSUI FUDOSAN CO., LTD.
+        weight: 0.000000
+      8802.T:
+        name: MITSUBISHI ESTATE CO., LTD.
+        weight: 0.000000
+      8830.T:
+        name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+        weight: 0.000000
+      9432.T:
+        name: NTT, INC.
+        weight: 0.200000
+      9613.T:
+        name: NOMURA RESEARCH INSTITUTE, LTD.
+        weight: 0.000000
+      9983.T:
+        name: FAST RETAILING CO., LTD.
+        weight: 0.000000
+      9984.T:
+        name: SOFTBANK GROUP CORP.
+        weight: 0.000000
+universe:
+  count: 70
+  members:
+    -
+      ticker: 1332.T
+      name: Nissui
+    -
+      ticker: 1605.T
+      name: Inpex Corp
+    -
+      ticker: 1925.T
+      name: DAIWA HOUSE INDUSTRY CO., LTD.
+    -
+      ticker: 2802.T
+      name: AJINOMOTO CO., INC.
+    -
+      ticker: 2914.T
+      name: JAPAN TOBACCO INC.
+    -
+      ticker: 3382.T
+      name: SEVEN & I HOLDINGS CO., LTD.
+    -
+      ticker: 4061.T
+      name: Denka
+    -
+      ticker: 4063.T
+      name: Shin-Etsu Chemical
+    -
+      ticker: 4151.T
+      name: KYOWA KIRIN CO., LTD.
+    -
+      ticker: 4502.T
+      name: TAKEDA PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4503.T
+      name: ASTELLAS PHARMA INC.
+    -
+      ticker: 4506.T
+      name: SUMITOMO PHARMA CO., LTD.
+    -
+      ticker: 4507.T
+      name: SHIONOGI & CO., LTD.
+    -
+      ticker: 4519.T
+      name: CHUGAI PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4523.T
+      name: EISAI CO., LTD.
+    -
+      ticker: 4568.T
+      name: DAIICHI SANKYO CO., LTD.
+    -
+      ticker: 4661.T
+      name: ORIENTAL LAND CO., LTD.
+    -
+      ticker: 5714.T
+      name: DOWA Holdings
+    -
+      ticker: 5802.T
+      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+    -
+      ticker: 5803.T
+      name: FUJIKURA LTD.
+    -
+      ticker: 6301.T
+      name: KOMATSU LTD.
+    -
+      ticker: 6367.T
+      name: DAIKIN INDUSTRIES,LTD.
+    -
+      ticker: 6479.T
+      name: MINEBEA MITSUMI INC.
+    -
+      ticker: 6501.T
+      name: HITACHI, LTD.
+    -
+      ticker: 6503.T
+      name: MITSUBISHI ELECTRIC CORP.
+    -
+      ticker: 6504.T
+      name: FUJI ELECTRIC CO., LTD.
+    -
+      ticker: 6506.T
+      name: YASKAWA ELECTRIC CORP.
+    -
+      ticker: 6594.T
+      name: NIDEC CORP.
+    -
+      ticker: 6645.T
+      name: OMRON CORP.
+    -
+      ticker: 6674.T
+      name: GS YUASA CORP.
+    -
+      ticker: 6701.T
+      name: NEC CORP.
+    -
+      ticker: 6702.T
+      name: FUJITSU LTD.
+    -
+      ticker: 6723.T
+      name: RENESAS ELECTRONICS CORP.
+    -
+      ticker: 6724.T
+      name: SEIKO EPSON CORP.
+    -
+      ticker: 6752.T
+      name: PANASONIC HOLDINGS CORP.
+    -
+      ticker: 6753.T
+      name: SHARP CORP.
+    -
+      ticker: 6758.T
+      name: SONY GROUP CORP.
+    -
+      ticker: 6762.T
+      name: TDK CORP.
+    -
+      ticker: 6770.T
+      name: ALPS ALPINE CO., LTD.
+    -
+      ticker: 6841.T
+      name: YOKOGAWA ELECTRIC CORP.
+    -
+      ticker: 6857.T
+      name: ADVANTEST CORP.
+    -
+      ticker: 6861.T
+      name: KEYENCE CORP.
+    -
+      ticker: 6902.T
+      name: DENSO CORP.
+    -
+      ticker: 6952.T
+      name: CASIO COMPUTER CO., LTD.
+    -
+      ticker: 6954.T
+      name: FANUC CORP.
+    -
+      ticker: 6963.T
+      name: ROHM CO., LTD.
+    -
+      ticker: 6981.T
+      name: MURATA MANUFACTURING CO., LTD.
+    -
+      ticker: 7011.T
+      name: Mitsubishi Heavy Industries
+    -
+      ticker: 7012.T
+      name: Kawasaki Heavy Industries
+    -
+      ticker: 7267.T
+      name: HONDA MOTOR CO., LTD.
+    -
+      ticker: 7751.T
+      name: CANON INC.
+    -
+      ticker: 7832.T
+      name: BANDAI NAMCO HOLDINGS INC.
+    -
+      ticker: 7974.T
+      name: NINTENDO CO., LTD.
+    -
+      ticker: 8031.T
+      name: MITSUI & CO., LTD.
+    -
+      ticker: 8267.T
+      name: AEON CO., LTD.
+    -
+      ticker: 8306.T
+      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+    -
+      ticker: 8308.T
+      name: RESONA HOLDINGS, INC.
+    -
+      ticker: 8309.T
+      name: SUMITOMO MITSUI TRUST GROUP, INC.
+    -
+      ticker: 8316.T
+      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+    -
+      ticker: 8411.T
+      name: MIZUHO FINANCIAL GROUP, INC.
+    -
+      ticker: 8604.T
+      name: NOMURA HOLDINGS, INC.
+    -
+      ticker: 8725.T
+      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+    -
+      ticker: 8766.T
+      name: TOKIO MARINE HOLDINGS, INC.
+    -
+      ticker: 8801.T
+      name: MITSUI FUDOSAN CO., LTD.
+    -
+      ticker: 8802.T
+      name: MITSUBISHI ESTATE CO., LTD.
+    -
+      ticker: 8830.T
+      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+    -
+      ticker: 9432.T
+      name: NTT, INC.
+    -
+      ticker: 9613.T
+      name: NOMURA RESEARCH INSTITUTE, LTD.
+    -
+      ticker: 9983.T
+      name: FAST RETAILING CO., LTD.
+    -
+      ticker: 9984.T
+      name: SOFTBANK GROUP CORP.

--- a/reports/portfolio/2017.yaml
+++ b/reports/portfolio/2017.yaml
@@ -1,437 +1,593 @@
+year: 2017
 period:
   start: 2017-01-01
   end: 2017-12-31
-universe:
-  -
-    ticker: 1332.T
-    name: Nissui
-  -
-    ticker: 4061.T
-    name: Denka
-  -
-    ticker: 5714.T
-    name: DOWA Holdings
-  -
-    ticker: 7011.T
-    name: Mitsubishi Heavy Industries
-  -
-    ticker: 8604.T
-    name: NOMURA HOLDINGS, INC.
-  -
-    ticker: 4063.T
-    name: Shin-Etsu Chemical
-  -
-    ticker: 7012.T
-    name: Kawasaki Heavy Industries
-  -
-    ticker: 1605.T
-    name: Inpex Corp
-  -
-    ticker: 4151.T
-    name: KYOWA KIRIN CO., LTD.
-  -
-    ticker: 4502.T
-    name: TAKEDA PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4503.T
-    name: ASTELLAS PHARMA INC.
-  -
-    ticker: 4506.T
-    name: SUMITOMO PHARMA CO., LTD.
-  -
-    ticker: 4507.T
-    name: SHIONOGI & CO., LTD.
-  -
-    ticker: 4519.T
-    name: CHUGAI PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4523.T
-    name: EISAI CO., LTD.
-  -
-    ticker: 4568.T
-    name: DAIICHI SANKYO CO., LTD.
-  -
-    ticker: 6479.T
-    name: MINEBEA MITSUMI INC.
-  -
-    ticker: 6501.T
-    name: HITACHI, LTD.
-  -
-    ticker: 6503.T
-    name: MITSUBISHI ELECTRIC CORP.
-  -
-    ticker: 6504.T
-    name: FUJI ELECTRIC CO., LTD.
-  -
-    ticker: 6506.T
-    name: YASKAWA ELECTRIC CORP.
-  -
-    ticker: 6594.T
-    name: NIDEC CORP.
-  -
-    ticker: 6645.T
-    name: OMRON CORP.
-  -
-    ticker: 6674.T
-    name: GS YUASA CORP.
-  -
-    ticker: 6701.T
-    name: NEC CORP.
-  -
-    ticker: 6702.T
-    name: FUJITSU LTD.
-  -
-    ticker: 6723.T
-    name: RENESAS ELECTRONICS CORP.
-  -
-    ticker: 6724.T
-    name: SEIKO EPSON CORP.
-  -
-    ticker: 6752.T
-    name: PANASONIC HOLDINGS CORP.
-  -
-    ticker: 6753.T
-    name: SHARP CORP.
-  -
-    ticker: 6758.T
-    name: SONY GROUP CORP.
-  -
-    ticker: 6762.T
-    name: TDK CORP.
-  -
-    ticker: 6770.T
-    name: ALPS ALPINE CO., LTD.
-  -
-    ticker: 6841.T
-    name: YOKOGAWA ELECTRIC CORP.
-  -
-    ticker: 6857.T
-    name: ADVANTEST CORP.
-  -
-    ticker: 6861.T
-    name: KEYENCE CORP.
-  -
-    ticker: 6902.T
-    name: DENSO CORP.
-  -
-    ticker: 6952.T
-    name: CASIO COMPUTER CO., LTD.
-  -
-    ticker: 6954.T
-    name: FANUC CORP.
-  -
-    ticker: 6963.T
-    name: ROHM CO., LTD.
-  -
-    ticker: 9984.T
-    name: SOFTBANK GROUP CORP.
-  -
-    ticker: 8306.T
-    name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-  -
-    ticker: 8316.T
-    name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-  -
-    ticker: 7974.T
-    name: NINTENDO CO., LTD.
-  -
-    ticker: 9983.T
-    name: FAST RETAILING CO., LTD.
-  -
-    ticker: 9432.T
-    name: NTT, INC.
-  -
-    ticker: 8411.T
-    name: MIZUHO FINANCIAL GROUP, INC.
-  -
-    ticker: 8766.T
-    name: TOKIO MARINE HOLDINGS, INC.
-  -
-    ticker: 8031.T
-    name: MITSUI & CO., LTD.
-  -
-    ticker: 2914.T
-    name: JAPAN TOBACCO INC.
-  -
-    ticker: 7267.T
-    name: HONDA MOTOR CO., LTD.
-  -
-    ticker: 4661.T
-    name: ORIENTAL LAND CO., LTD.
-  -
-    ticker: 6981.T
-    name: MURATA MANUFACTURING CO., LTD.
-  -
-    ticker: 6367.T
-    name: DAIKIN INDUSTRIES,LTD.
-  -
-    ticker: 8725.T
-    name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-  -
-    ticker: 3382.T
-    name: SEVEN & I HOLDINGS CO., LTD.
-  -
-    ticker: 6301.T
-    name: KOMATSU LTD.
-  -
-    ticker: 8267.T
-    name: AEON CO., LTD.
-  -
-    ticker: 8801.T
-    name: MITSUI FUDOSAN CO., LTD.
-  -
-    ticker: 2802.T
-    name: AJINOMOTO CO., INC.
-  -
-    ticker: 8802.T
-    name: MITSUBISHI ESTATE CO., LTD.
-  -
-    ticker: 5803.T
-    name: FUJIKURA LTD.
-  -
-    ticker: 7751.T
-    name: CANON INC.
-  -
-    ticker: 8308.T
-    name: RESONA HOLDINGS, INC.
-  -
-    ticker: 5802.T
-    name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-  -
-    ticker: 9613.T
-    name: NOMURA RESEARCH INSTITUTE, LTD.
-  -
-    ticker: 1925.T
-    name: DAIWA HOUSE INDUSTRY CO., LTD.
-  -
-    ticker: 7832.T
-    name: BANDAI NAMCO HOLDINGS INC.
-  -
-    ticker: 8830.T
-    name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-  -
-    ticker: 8309.T
-    name: SUMITOMO MITSUI TRUST GROUP, INC.
+conditions:
+  training_window:
+    start: 2016-04-25 09:00:00+09:00
+    end: 2016-12-30 09:00:00+09:00
+  evaluation_window:
+    start: 2017-01-04 09:00:00+09:00
+    end: 2017-12-29 09:00:00+09:00
 portfolio:
-  weights:
-    1332.T:
-      name: Nissui
-      weight: 0.000000
-    4061.T:
-      name: Denka
-      weight: 0.000000
-    5714.T:
-      name: DOWA Holdings
-      weight: 0.000000
-    7011.T:
-      name: Mitsubishi Heavy Industries
-      weight: 0.000000
-    8604.T:
-      name: NOMURA HOLDINGS, INC.
-      weight: 0.000000
-    4063.T:
-      name: Shin-Etsu Chemical
-      weight: 0.077671
-    7012.T:
-      name: Kawasaki Heavy Industries
-      weight: 0.000000
-    1605.T:
-      name: Inpex Corp
-      weight: 0.000000
-    4151.T:
-      name: KYOWA KIRIN CO., LTD.
-      weight: 0.000000
-    4502.T:
-      name: TAKEDA PHARMACEUTICAL CO., LTD.
-      weight: 0.000000
-    4503.T:
-      name: ASTELLAS PHARMA INC.
-      weight: 0.000000
-    4506.T:
-      name: SUMITOMO PHARMA CO., LTD.
-      weight: 0.200000
-    4507.T:
-      name: SHIONOGI & CO., LTD.
-      weight: 0.000000
-    4519.T:
-      name: CHUGAI PHARMACEUTICAL CO., LTD.
-      weight: 0.000000
-    4523.T:
-      name: EISAI CO., LTD.
-      weight: 0.000000
-    4568.T:
-      name: DAIICHI SANKYO CO., LTD.
-      weight: 0.000000
-    6479.T:
-      name: MINEBEA MITSUMI INC.
-      weight: 0.000000
-    6501.T:
-      name: HITACHI, LTD.
-      weight: 0.000000
-    6503.T:
-      name: MITSUBISHI ELECTRIC CORP.
-      weight: 0.000000
-    6504.T:
-      name: FUJI ELECTRIC CO., LTD.
-      weight: 0.114102
-    6506.T:
-      name: YASKAWA ELECTRIC CORP.
-      weight: 0.000000
-    6594.T:
-      name: NIDEC CORP.
-      weight: 0.000000
-    6645.T:
-      name: OMRON CORP.
-      weight: 0.000000
-    6674.T:
-      name: GS YUASA CORP.
-      weight: 0.000000
-    6701.T:
-      name: NEC CORP.
-      weight: 0.000000
-    6702.T:
-      name: FUJITSU LTD.
-      weight: 0.035269
-    6723.T:
-      name: RENESAS ELECTRONICS CORP.
-      weight: 0.000000
-    6724.T:
-      name: SEIKO EPSON CORP.
-      weight: 0.000000
-    6752.T:
-      name: PANASONIC HOLDINGS CORP.
-      weight: 0.000000
-    6753.T:
-      name: SHARP CORP.
-      weight: 0.146676
-    6758.T:
-      name: SONY GROUP CORP.
-      weight: 0.000000
-    6762.T:
-      name: TDK CORP.
-      weight: 0.000000
-    6770.T:
-      name: ALPS ALPINE CO., LTD.
-      weight: 0.000000
-    6841.T:
-      name: YOKOGAWA ELECTRIC CORP.
-      weight: 0.000000
-    6857.T:
-      name: ADVANTEST CORP.
-      weight: 0.200000
-    6861.T:
-      name: KEYENCE CORP.
-      weight: 0.000000
-    6902.T:
-      name: DENSO CORP.
-      weight: 0.000000
-    6952.T:
-      name: CASIO COMPUTER CO., LTD.
-      weight: 0.000000
-    6954.T:
-      name: FANUC CORP.
-      weight: 0.000000
-    6963.T:
-      name: ROHM CO., LTD.
-      weight: 0.000000
-    9984.T:
-      name: SOFTBANK GROUP CORP.
-      weight: 0.000000
-    8306.T:
-      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8316.T:
-      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-      weight: 0.000000
-    7974.T:
-      name: NINTENDO CO., LTD.
-      weight: 0.006929
-    9983.T:
-      name: FAST RETAILING CO., LTD.
-      weight: 0.000000
-    9432.T:
-      name: NTT, INC.
-      weight: 0.000000
-    8411.T:
-      name: MIZUHO FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8766.T:
-      name: TOKIO MARINE HOLDINGS, INC.
-      weight: 0.000000
-    8031.T:
-      name: MITSUI & CO., LTD.
-      weight: 0.000000
-    2914.T:
-      name: JAPAN TOBACCO INC.
-      weight: 0.000000
-    7267.T:
-      name: HONDA MOTOR CO., LTD.
-      weight: 0.000000
-    4661.T:
-      name: ORIENTAL LAND CO., LTD.
-      weight: 0.000000
-    6981.T:
-      name: MURATA MANUFACTURING CO., LTD.
-      weight: 0.000000
-    6367.T:
-      name: DAIKIN INDUSTRIES,LTD.
-      weight: 0.000000
-    8725.T:
-      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-      weight: 0.000000
-    3382.T:
-      name: SEVEN & I HOLDINGS CO., LTD.
-      weight: 0.000000
-    6301.T:
-      name: KOMATSU LTD.
-      weight: 0.000000
-    8267.T:
-      name: AEON CO., LTD.
-      weight: 0.000000
-    8801.T:
-      name: MITSUI FUDOSAN CO., LTD.
-      weight: 0.000000
-    2802.T:
-      name: AJINOMOTO CO., INC.
-      weight: 0.000000
-    8802.T:
-      name: MITSUBISHI ESTATE CO., LTD.
-      weight: 0.000000
-    5803.T:
-      name: FUJIKURA LTD.
-      weight: 0.000000
-    7751.T:
-      name: CANON INC.
-      weight: 0.000000
-    8308.T:
-      name: RESONA HOLDINGS, INC.
-      weight: 0.019352
-    5802.T:
-      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-      weight: 0.000000
-    9613.T:
-      name: NOMURA RESEARCH INSTITUTE, LTD.
-      weight: 0.000000
-    1925.T:
-      name: DAIWA HOUSE INDUSTRY CO., LTD.
-      weight: 0.000000
-    7832.T:
-      name: BANDAI NAMCO HOLDINGS INC.
-      weight: 0.200000
-    8830.T:
-      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-      weight: 0.000000
-    8309.T:
-      name: SUMITOMO MITSUI TRUST GROUP, INC.
-      weight: 0.000000
   risk_metrics:
     annual_return: 0.163218
     volatility: 0.158650
     sharpe_ratio: 1.028793
     max_drawdown: -0.117513
-  training_window:
-    start: 2016-04-25T09:00:00+09:00
-    end: 2016-12-30T09:00:00+09:00
-  evaluation_window:
-    start: 2017-01-04T09:00:00+09:00
-    end: 2017-12-29T09:00:00+09:00
+  allocations:
+    summary:
+      total_constituents: 70
+      invested_constituents: 9
+      zero_weight_constituents: 61
+      top3_weight: 0.600000
+      top10_weight: 0.999999
+    top_holdings:
+      -
+        rank: 1
+        ticker: 4506.T
+        name: SUMITOMO PHARMA CO., LTD.
+        weight: 0.200000
+      -
+        rank: 2
+        ticker: 6857.T
+        name: ADVANTEST CORP.
+        weight: 0.200000
+      -
+        rank: 3
+        ticker: 7832.T
+        name: BANDAI NAMCO HOLDINGS INC.
+        weight: 0.200000
+      -
+        rank: 4
+        ticker: 6753.T
+        name: SHARP CORP.
+        weight: 0.146676
+      -
+        rank: 5
+        ticker: 6504.T
+        name: FUJI ELECTRIC CO., LTD.
+        weight: 0.114102
+      -
+        rank: 6
+        ticker: 4063.T
+        name: Shin-Etsu Chemical
+        weight: 0.077671
+      -
+        rank: 7
+        ticker: 6702.T
+        name: FUJITSU LTD.
+        weight: 0.035269
+      -
+        rank: 8
+        ticker: 8308.T
+        name: RESONA HOLDINGS, INC.
+        weight: 0.019352
+      -
+        rank: 9
+        ticker: 7974.T
+        name: NINTENDO CO., LTD.
+        weight: 0.006929
+      -
+        rank: 10
+        ticker: 1332.T
+        name: Nissui
+        weight: 0.000000
+    smallest_active_weights:
+      -
+        ticker: 7974.T
+        name: NINTENDO CO., LTD.
+        weight: 0.006929
+      -
+        ticker: 8308.T
+        name: RESONA HOLDINGS, INC.
+        weight: 0.019352
+      -
+        ticker: 6702.T
+        name: FUJITSU LTD.
+        weight: 0.035269
+      -
+        ticker: 4063.T
+        name: Shin-Etsu Chemical
+        weight: 0.077671
+      -
+        ticker: 6504.T
+        name: FUJI ELECTRIC CO., LTD.
+        weight: 0.114102
+    weight_buckets:
+      -
+        label: 10%以上
+        count: 5
+        weight_share: 0.860778
+        sample:
+          -
+            ticker: 4506.T
+            name: SUMITOMO PHARMA CO., LTD.
+            weight: 0.200000
+          -
+            ticker: 6857.T
+            name: ADVANTEST CORP.
+            weight: 0.200000
+          -
+            ticker: 7832.T
+            name: BANDAI NAMCO HOLDINGS INC.
+            weight: 0.200000
+          -
+            ticker: 6753.T
+            name: SHARP CORP.
+            weight: 0.146676
+          -
+            ticker: 6504.T
+            name: FUJI ELECTRIC CO., LTD.
+            weight: 0.114102
+      -
+        label: 5%-10%
+        count: 1
+        weight_share: 0.077671
+        sample:
+          -
+            ticker: 4063.T
+            name: Shin-Etsu Chemical
+            weight: 0.077671
+      -
+        label: 1%-5%
+        count: 2
+        weight_share: 0.054621
+        sample:
+          -
+            ticker: 6702.T
+            name: FUJITSU LTD.
+            weight: 0.035269
+          -
+            ticker: 8308.T
+            name: RESONA HOLDINGS, INC.
+            weight: 0.019352
+      -
+        label: 1%未満
+        count: 62
+        weight_share: 0.006929
+        sample:
+          -
+            ticker: 7974.T
+            name: NINTENDO CO., LTD.
+            weight: 0.006929
+          -
+            ticker: 1332.T
+            name: Nissui
+            weight: 0.000000
+          -
+            ticker: 4061.T
+            name: Denka
+            weight: 0.000000
+          -
+            ticker: 5714.T
+            name: DOWA Holdings
+            weight: 0.000000
+          -
+            ticker: 7011.T
+            name: Mitsubishi Heavy Industries
+            weight: 0.000000
+    by_ticker:
+      1332.T:
+        name: Nissui
+        weight: 0.000000
+      1605.T:
+        name: Inpex Corp
+        weight: 0.000000
+      1925.T:
+        name: DAIWA HOUSE INDUSTRY CO., LTD.
+        weight: 0.000000
+      2802.T:
+        name: AJINOMOTO CO., INC.
+        weight: 0.000000
+      2914.T:
+        name: JAPAN TOBACCO INC.
+        weight: 0.000000
+      3382.T:
+        name: SEVEN & I HOLDINGS CO., LTD.
+        weight: 0.000000
+      4061.T:
+        name: Denka
+        weight: 0.000000
+      4063.T:
+        name: Shin-Etsu Chemical
+        weight: 0.077671
+      4151.T:
+        name: KYOWA KIRIN CO., LTD.
+        weight: 0.000000
+      4502.T:
+        name: TAKEDA PHARMACEUTICAL CO., LTD.
+        weight: 0.000000
+      4503.T:
+        name: ASTELLAS PHARMA INC.
+        weight: 0.000000
+      4506.T:
+        name: SUMITOMO PHARMA CO., LTD.
+        weight: 0.200000
+      4507.T:
+        name: SHIONOGI & CO., LTD.
+        weight: 0.000000
+      4519.T:
+        name: CHUGAI PHARMACEUTICAL CO., LTD.
+        weight: 0.000000
+      4523.T:
+        name: EISAI CO., LTD.
+        weight: 0.000000
+      4568.T:
+        name: DAIICHI SANKYO CO., LTD.
+        weight: 0.000000
+      4661.T:
+        name: ORIENTAL LAND CO., LTD.
+        weight: 0.000000
+      5714.T:
+        name: DOWA Holdings
+        weight: 0.000000
+      5802.T:
+        name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+        weight: 0.000000
+      5803.T:
+        name: FUJIKURA LTD.
+        weight: 0.000000
+      6301.T:
+        name: KOMATSU LTD.
+        weight: 0.000000
+      6367.T:
+        name: DAIKIN INDUSTRIES,LTD.
+        weight: 0.000000
+      6479.T:
+        name: MINEBEA MITSUMI INC.
+        weight: 0.000000
+      6501.T:
+        name: HITACHI, LTD.
+        weight: 0.000000
+      6503.T:
+        name: MITSUBISHI ELECTRIC CORP.
+        weight: 0.000000
+      6504.T:
+        name: FUJI ELECTRIC CO., LTD.
+        weight: 0.114102
+      6506.T:
+        name: YASKAWA ELECTRIC CORP.
+        weight: 0.000000
+      6594.T:
+        name: NIDEC CORP.
+        weight: 0.000000
+      6645.T:
+        name: OMRON CORP.
+        weight: 0.000000
+      6674.T:
+        name: GS YUASA CORP.
+        weight: 0.000000
+      6701.T:
+        name: NEC CORP.
+        weight: 0.000000
+      6702.T:
+        name: FUJITSU LTD.
+        weight: 0.035269
+      6723.T:
+        name: RENESAS ELECTRONICS CORP.
+        weight: 0.000000
+      6724.T:
+        name: SEIKO EPSON CORP.
+        weight: 0.000000
+      6752.T:
+        name: PANASONIC HOLDINGS CORP.
+        weight: 0.000000
+      6753.T:
+        name: SHARP CORP.
+        weight: 0.146676
+      6758.T:
+        name: SONY GROUP CORP.
+        weight: 0.000000
+      6762.T:
+        name: TDK CORP.
+        weight: 0.000000
+      6770.T:
+        name: ALPS ALPINE CO., LTD.
+        weight: 0.000000
+      6841.T:
+        name: YOKOGAWA ELECTRIC CORP.
+        weight: 0.000000
+      6857.T:
+        name: ADVANTEST CORP.
+        weight: 0.200000
+      6861.T:
+        name: KEYENCE CORP.
+        weight: 0.000000
+      6902.T:
+        name: DENSO CORP.
+        weight: 0.000000
+      6952.T:
+        name: CASIO COMPUTER CO., LTD.
+        weight: 0.000000
+      6954.T:
+        name: FANUC CORP.
+        weight: 0.000000
+      6963.T:
+        name: ROHM CO., LTD.
+        weight: 0.000000
+      6981.T:
+        name: MURATA MANUFACTURING CO., LTD.
+        weight: 0.000000
+      7011.T:
+        name: Mitsubishi Heavy Industries
+        weight: 0.000000
+      7012.T:
+        name: Kawasaki Heavy Industries
+        weight: 0.000000
+      7267.T:
+        name: HONDA MOTOR CO., LTD.
+        weight: 0.000000
+      7751.T:
+        name: CANON INC.
+        weight: 0.000000
+      7832.T:
+        name: BANDAI NAMCO HOLDINGS INC.
+        weight: 0.200000
+      7974.T:
+        name: NINTENDO CO., LTD.
+        weight: 0.006929
+      8031.T:
+        name: MITSUI & CO., LTD.
+        weight: 0.000000
+      8267.T:
+        name: AEON CO., LTD.
+        weight: 0.000000
+      8306.T:
+        name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8308.T:
+        name: RESONA HOLDINGS, INC.
+        weight: 0.019352
+      8309.T:
+        name: SUMITOMO MITSUI TRUST GROUP, INC.
+        weight: 0.000000
+      8316.T:
+        name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8411.T:
+        name: MIZUHO FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8604.T:
+        name: NOMURA HOLDINGS, INC.
+        weight: 0.000000
+      8725.T:
+        name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+        weight: 0.000000
+      8766.T:
+        name: TOKIO MARINE HOLDINGS, INC.
+        weight: 0.000000
+      8801.T:
+        name: MITSUI FUDOSAN CO., LTD.
+        weight: 0.000000
+      8802.T:
+        name: MITSUBISHI ESTATE CO., LTD.
+        weight: 0.000000
+      8830.T:
+        name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+        weight: 0.000000
+      9432.T:
+        name: NTT, INC.
+        weight: 0.000000
+      9613.T:
+        name: NOMURA RESEARCH INSTITUTE, LTD.
+        weight: 0.000000
+      9983.T:
+        name: FAST RETAILING CO., LTD.
+        weight: 0.000000
+      9984.T:
+        name: SOFTBANK GROUP CORP.
+        weight: 0.000000
+universe:
+  count: 70
+  members:
+    -
+      ticker: 1332.T
+      name: Nissui
+    -
+      ticker: 1605.T
+      name: Inpex Corp
+    -
+      ticker: 1925.T
+      name: DAIWA HOUSE INDUSTRY CO., LTD.
+    -
+      ticker: 2802.T
+      name: AJINOMOTO CO., INC.
+    -
+      ticker: 2914.T
+      name: JAPAN TOBACCO INC.
+    -
+      ticker: 3382.T
+      name: SEVEN & I HOLDINGS CO., LTD.
+    -
+      ticker: 4061.T
+      name: Denka
+    -
+      ticker: 4063.T
+      name: Shin-Etsu Chemical
+    -
+      ticker: 4151.T
+      name: KYOWA KIRIN CO., LTD.
+    -
+      ticker: 4502.T
+      name: TAKEDA PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4503.T
+      name: ASTELLAS PHARMA INC.
+    -
+      ticker: 4506.T
+      name: SUMITOMO PHARMA CO., LTD.
+    -
+      ticker: 4507.T
+      name: SHIONOGI & CO., LTD.
+    -
+      ticker: 4519.T
+      name: CHUGAI PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4523.T
+      name: EISAI CO., LTD.
+    -
+      ticker: 4568.T
+      name: DAIICHI SANKYO CO., LTD.
+    -
+      ticker: 4661.T
+      name: ORIENTAL LAND CO., LTD.
+    -
+      ticker: 5714.T
+      name: DOWA Holdings
+    -
+      ticker: 5802.T
+      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+    -
+      ticker: 5803.T
+      name: FUJIKURA LTD.
+    -
+      ticker: 6301.T
+      name: KOMATSU LTD.
+    -
+      ticker: 6367.T
+      name: DAIKIN INDUSTRIES,LTD.
+    -
+      ticker: 6479.T
+      name: MINEBEA MITSUMI INC.
+    -
+      ticker: 6501.T
+      name: HITACHI, LTD.
+    -
+      ticker: 6503.T
+      name: MITSUBISHI ELECTRIC CORP.
+    -
+      ticker: 6504.T
+      name: FUJI ELECTRIC CO., LTD.
+    -
+      ticker: 6506.T
+      name: YASKAWA ELECTRIC CORP.
+    -
+      ticker: 6594.T
+      name: NIDEC CORP.
+    -
+      ticker: 6645.T
+      name: OMRON CORP.
+    -
+      ticker: 6674.T
+      name: GS YUASA CORP.
+    -
+      ticker: 6701.T
+      name: NEC CORP.
+    -
+      ticker: 6702.T
+      name: FUJITSU LTD.
+    -
+      ticker: 6723.T
+      name: RENESAS ELECTRONICS CORP.
+    -
+      ticker: 6724.T
+      name: SEIKO EPSON CORP.
+    -
+      ticker: 6752.T
+      name: PANASONIC HOLDINGS CORP.
+    -
+      ticker: 6753.T
+      name: SHARP CORP.
+    -
+      ticker: 6758.T
+      name: SONY GROUP CORP.
+    -
+      ticker: 6762.T
+      name: TDK CORP.
+    -
+      ticker: 6770.T
+      name: ALPS ALPINE CO., LTD.
+    -
+      ticker: 6841.T
+      name: YOKOGAWA ELECTRIC CORP.
+    -
+      ticker: 6857.T
+      name: ADVANTEST CORP.
+    -
+      ticker: 6861.T
+      name: KEYENCE CORP.
+    -
+      ticker: 6902.T
+      name: DENSO CORP.
+    -
+      ticker: 6952.T
+      name: CASIO COMPUTER CO., LTD.
+    -
+      ticker: 6954.T
+      name: FANUC CORP.
+    -
+      ticker: 6963.T
+      name: ROHM CO., LTD.
+    -
+      ticker: 6981.T
+      name: MURATA MANUFACTURING CO., LTD.
+    -
+      ticker: 7011.T
+      name: Mitsubishi Heavy Industries
+    -
+      ticker: 7012.T
+      name: Kawasaki Heavy Industries
+    -
+      ticker: 7267.T
+      name: HONDA MOTOR CO., LTD.
+    -
+      ticker: 7751.T
+      name: CANON INC.
+    -
+      ticker: 7832.T
+      name: BANDAI NAMCO HOLDINGS INC.
+    -
+      ticker: 7974.T
+      name: NINTENDO CO., LTD.
+    -
+      ticker: 8031.T
+      name: MITSUI & CO., LTD.
+    -
+      ticker: 8267.T
+      name: AEON CO., LTD.
+    -
+      ticker: 8306.T
+      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+    -
+      ticker: 8308.T
+      name: RESONA HOLDINGS, INC.
+    -
+      ticker: 8309.T
+      name: SUMITOMO MITSUI TRUST GROUP, INC.
+    -
+      ticker: 8316.T
+      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+    -
+      ticker: 8411.T
+      name: MIZUHO FINANCIAL GROUP, INC.
+    -
+      ticker: 8604.T
+      name: NOMURA HOLDINGS, INC.
+    -
+      ticker: 8725.T
+      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+    -
+      ticker: 8766.T
+      name: TOKIO MARINE HOLDINGS, INC.
+    -
+      ticker: 8801.T
+      name: MITSUI FUDOSAN CO., LTD.
+    -
+      ticker: 8802.T
+      name: MITSUBISHI ESTATE CO., LTD.
+    -
+      ticker: 8830.T
+      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+    -
+      ticker: 9432.T
+      name: NTT, INC.
+    -
+      ticker: 9613.T
+      name: NOMURA RESEARCH INSTITUTE, LTD.
+    -
+      ticker: 9983.T
+      name: FAST RETAILING CO., LTD.
+    -
+      ticker: 9984.T
+      name: SOFTBANK GROUP CORP.

--- a/reports/portfolio/2018.yaml
+++ b/reports/portfolio/2018.yaml
@@ -1,437 +1,605 @@
+year: 2018
 period:
   start: 2018-01-01
   end: 2018-12-31
-universe:
-  -
-    ticker: 1332.T
-    name: Nissui
-  -
-    ticker: 4061.T
-    name: Denka
-  -
-    ticker: 5714.T
-    name: DOWA Holdings
-  -
-    ticker: 7011.T
-    name: Mitsubishi Heavy Industries
-  -
-    ticker: 8604.T
-    name: NOMURA HOLDINGS, INC.
-  -
-    ticker: 4063.T
-    name: Shin-Etsu Chemical
-  -
-    ticker: 7012.T
-    name: Kawasaki Heavy Industries
-  -
-    ticker: 1605.T
-    name: Inpex Corp
-  -
-    ticker: 4151.T
-    name: KYOWA KIRIN CO., LTD.
-  -
-    ticker: 4502.T
-    name: TAKEDA PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4503.T
-    name: ASTELLAS PHARMA INC.
-  -
-    ticker: 4506.T
-    name: SUMITOMO PHARMA CO., LTD.
-  -
-    ticker: 4507.T
-    name: SHIONOGI & CO., LTD.
-  -
-    ticker: 4519.T
-    name: CHUGAI PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4523.T
-    name: EISAI CO., LTD.
-  -
-    ticker: 4568.T
-    name: DAIICHI SANKYO CO., LTD.
-  -
-    ticker: 6479.T
-    name: MINEBEA MITSUMI INC.
-  -
-    ticker: 6501.T
-    name: HITACHI, LTD.
-  -
-    ticker: 6503.T
-    name: MITSUBISHI ELECTRIC CORP.
-  -
-    ticker: 6504.T
-    name: FUJI ELECTRIC CO., LTD.
-  -
-    ticker: 6506.T
-    name: YASKAWA ELECTRIC CORP.
-  -
-    ticker: 6594.T
-    name: NIDEC CORP.
-  -
-    ticker: 6645.T
-    name: OMRON CORP.
-  -
-    ticker: 6674.T
-    name: GS YUASA CORP.
-  -
-    ticker: 6701.T
-    name: NEC CORP.
-  -
-    ticker: 6702.T
-    name: FUJITSU LTD.
-  -
-    ticker: 6723.T
-    name: RENESAS ELECTRONICS CORP.
-  -
-    ticker: 6724.T
-    name: SEIKO EPSON CORP.
-  -
-    ticker: 6752.T
-    name: PANASONIC HOLDINGS CORP.
-  -
-    ticker: 6753.T
-    name: SHARP CORP.
-  -
-    ticker: 6758.T
-    name: SONY GROUP CORP.
-  -
-    ticker: 6762.T
-    name: TDK CORP.
-  -
-    ticker: 6770.T
-    name: ALPS ALPINE CO., LTD.
-  -
-    ticker: 6841.T
-    name: YOKOGAWA ELECTRIC CORP.
-  -
-    ticker: 6857.T
-    name: ADVANTEST CORP.
-  -
-    ticker: 6861.T
-    name: KEYENCE CORP.
-  -
-    ticker: 6902.T
-    name: DENSO CORP.
-  -
-    ticker: 6952.T
-    name: CASIO COMPUTER CO., LTD.
-  -
-    ticker: 6954.T
-    name: FANUC CORP.
-  -
-    ticker: 6963.T
-    name: ROHM CO., LTD.
-  -
-    ticker: 9984.T
-    name: SOFTBANK GROUP CORP.
-  -
-    ticker: 8306.T
-    name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-  -
-    ticker: 8316.T
-    name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-  -
-    ticker: 7974.T
-    name: NINTENDO CO., LTD.
-  -
-    ticker: 9983.T
-    name: FAST RETAILING CO., LTD.
-  -
-    ticker: 9432.T
-    name: NTT, INC.
-  -
-    ticker: 8411.T
-    name: MIZUHO FINANCIAL GROUP, INC.
-  -
-    ticker: 8766.T
-    name: TOKIO MARINE HOLDINGS, INC.
-  -
-    ticker: 8031.T
-    name: MITSUI & CO., LTD.
-  -
-    ticker: 2914.T
-    name: JAPAN TOBACCO INC.
-  -
-    ticker: 7267.T
-    name: HONDA MOTOR CO., LTD.
-  -
-    ticker: 4661.T
-    name: ORIENTAL LAND CO., LTD.
-  -
-    ticker: 6981.T
-    name: MURATA MANUFACTURING CO., LTD.
-  -
-    ticker: 6367.T
-    name: DAIKIN INDUSTRIES,LTD.
-  -
-    ticker: 8725.T
-    name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-  -
-    ticker: 3382.T
-    name: SEVEN & I HOLDINGS CO., LTD.
-  -
-    ticker: 6301.T
-    name: KOMATSU LTD.
-  -
-    ticker: 8267.T
-    name: AEON CO., LTD.
-  -
-    ticker: 8801.T
-    name: MITSUI FUDOSAN CO., LTD.
-  -
-    ticker: 2802.T
-    name: AJINOMOTO CO., INC.
-  -
-    ticker: 8802.T
-    name: MITSUBISHI ESTATE CO., LTD.
-  -
-    ticker: 5803.T
-    name: FUJIKURA LTD.
-  -
-    ticker: 7751.T
-    name: CANON INC.
-  -
-    ticker: 8308.T
-    name: RESONA HOLDINGS, INC.
-  -
-    ticker: 5802.T
-    name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-  -
-    ticker: 9613.T
-    name: NOMURA RESEARCH INSTITUTE, LTD.
-  -
-    ticker: 1925.T
-    name: DAIWA HOUSE INDUSTRY CO., LTD.
-  -
-    ticker: 7832.T
-    name: BANDAI NAMCO HOLDINGS INC.
-  -
-    ticker: 8830.T
-    name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-  -
-    ticker: 8309.T
-    name: SUMITOMO MITSUI TRUST GROUP, INC.
+conditions:
+  training_window:
+    start: 2017-04-24 09:00:00+09:00
+    end: 2017-12-29 09:00:00+09:00
+  evaluation_window:
+    start: 2018-01-01 09:00:00+09:00
+    end: 2018-12-28 09:00:00+09:00
 portfolio:
-  weights:
-    1332.T:
-      name: Nissui
-      weight: 0.000000
-    4061.T:
-      name: Denka
-      weight: 0.109193
-    5714.T:
-      name: DOWA Holdings
-      weight: 0.000000
-    7011.T:
-      name: Mitsubishi Heavy Industries
-      weight: 0.000000
-    8604.T:
-      name: NOMURA HOLDINGS, INC.
-      weight: 0.000000
-    4063.T:
-      name: Shin-Etsu Chemical
-      weight: 0.000000
-    7012.T:
-      name: Kawasaki Heavy Industries
-      weight: 0.000000
-    1605.T:
-      name: Inpex Corp
-      weight: 0.137272
-    4151.T:
-      name: KYOWA KIRIN CO., LTD.
-      weight: 0.000000
-    4502.T:
-      name: TAKEDA PHARMACEUTICAL CO., LTD.
-      weight: 0.013381
-    4503.T:
-      name: ASTELLAS PHARMA INC.
-      weight: 0.000000
-    4506.T:
-      name: SUMITOMO PHARMA CO., LTD.
-      weight: 0.000000
-    4507.T:
-      name: SHIONOGI & CO., LTD.
-      weight: 0.000000
-    4519.T:
-      name: CHUGAI PHARMACEUTICAL CO., LTD.
-      weight: 0.076404
-    4523.T:
-      name: EISAI CO., LTD.
-      weight: 0.000000
-    4568.T:
-      name: DAIICHI SANKYO CO., LTD.
-      weight: 0.000000
-    6479.T:
-      name: MINEBEA MITSUMI INC.
-      weight: 0.000000
-    6501.T:
-      name: HITACHI, LTD.
-      weight: 0.065344
-    6503.T:
-      name: MITSUBISHI ELECTRIC CORP.
-      weight: 0.000000
-    6504.T:
-      name: FUJI ELECTRIC CO., LTD.
-      weight: 0.000000
-    6506.T:
-      name: YASKAWA ELECTRIC CORP.
-      weight: 0.183741
-    6594.T:
-      name: NIDEC CORP.
-      weight: 0.000000
-    6645.T:
-      name: OMRON CORP.
-      weight: 0.000000
-    6674.T:
-      name: GS YUASA CORP.
-      weight: 0.000000
-    6701.T:
-      name: NEC CORP.
-      weight: 0.000000
-    6702.T:
-      name: FUJITSU LTD.
-      weight: 0.000000
-    6723.T:
-      name: RENESAS ELECTRONICS CORP.
-      weight: 0.000000
-    6724.T:
-      name: SEIKO EPSON CORP.
-      weight: 0.000000
-    6752.T:
-      name: PANASONIC HOLDINGS CORP.
-      weight: 0.000000
-    6753.T:
-      name: SHARP CORP.
-      weight: 0.000000
-    6758.T:
-      name: SONY GROUP CORP.
-      weight: 0.000000
-    6762.T:
-      name: TDK CORP.
-      weight: 0.000000
-    6770.T:
-      name: ALPS ALPINE CO., LTD.
-      weight: 0.000000
-    6841.T:
-      name: YOKOGAWA ELECTRIC CORP.
-      weight: 0.000000
-    6857.T:
-      name: ADVANTEST CORP.
-      weight: 0.000000
-    6861.T:
-      name: KEYENCE CORP.
-      weight: 0.000000
-    6902.T:
-      name: DENSO CORP.
-      weight: 0.048655
-    6952.T:
-      name: CASIO COMPUTER CO., LTD.
-      weight: 0.000000
-    6954.T:
-      name: FANUC CORP.
-      weight: 0.000000
-    6963.T:
-      name: ROHM CO., LTD.
-      weight: 0.000000
-    9984.T:
-      name: SOFTBANK GROUP CORP.
-      weight: 0.000000
-    8306.T:
-      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8316.T:
-      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-      weight: 0.000000
-    7974.T:
-      name: NINTENDO CO., LTD.
-      weight: 0.063813
-    9983.T:
-      name: FAST RETAILING CO., LTD.
-      weight: 0.000000
-    9432.T:
-      name: NTT, INC.
-      weight: 0.000000
-    8411.T:
-      name: MIZUHO FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8766.T:
-      name: TOKIO MARINE HOLDINGS, INC.
-      weight: 0.000000
-    8031.T:
-      name: MITSUI & CO., LTD.
-      weight: 0.000000
-    2914.T:
-      name: JAPAN TOBACCO INC.
-      weight: 0.000000
-    7267.T:
-      name: HONDA MOTOR CO., LTD.
-      weight: 0.000000
-    4661.T:
-      name: ORIENTAL LAND CO., LTD.
-      weight: 0.200000
-    6981.T:
-      name: MURATA MANUFACTURING CO., LTD.
-      weight: 0.000000
-    6367.T:
-      name: DAIKIN INDUSTRIES,LTD.
-      weight: 0.000000
-    8725.T:
-      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-      weight: 0.000000
-    3382.T:
-      name: SEVEN & I HOLDINGS CO., LTD.
-      weight: 0.000000
-    6301.T:
-      name: KOMATSU LTD.
-      weight: 0.001182
-    8267.T:
-      name: AEON CO., LTD.
-      weight: 0.069196
-    8801.T:
-      name: MITSUI FUDOSAN CO., LTD.
-      weight: 0.000000
-    2802.T:
-      name: AJINOMOTO CO., INC.
-      weight: 0.000000
-    8802.T:
-      name: MITSUBISHI ESTATE CO., LTD.
-      weight: 0.000000
-    5803.T:
-      name: FUJIKURA LTD.
-      weight: 0.000000
-    7751.T:
-      name: CANON INC.
-      weight: 0.000000
-    8308.T:
-      name: RESONA HOLDINGS, INC.
-      weight: 0.000000
-    5802.T:
-      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-      weight: 0.000000
-    9613.T:
-      name: NOMURA RESEARCH INSTITUTE, LTD.
-      weight: 0.031820
-    1925.T:
-      name: DAIWA HOUSE INDUSTRY CO., LTD.
-      weight: 0.000000
-    7832.T:
-      name: BANDAI NAMCO HOLDINGS INC.
-      weight: 0.000000
-    8830.T:
-      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-      weight: 0.000000
-    8309.T:
-      name: SUMITOMO MITSUI TRUST GROUP, INC.
-      weight: 0.000000
   risk_metrics:
     annual_return: -0.190319
     volatility: 0.205709
     sharpe_ratio: -0.925184
     max_drawdown: -0.297521
-  training_window:
-    start: 2017-04-24T09:00:00+09:00
-    end: 2017-12-29T09:00:00+09:00
-  evaluation_window:
-    start: 2018-01-01T09:00:00+09:00
-    end: 2018-12-28T09:00:00+09:00
+  allocations:
+    summary:
+      total_constituents: 70
+      invested_constituents: 12
+      zero_weight_constituents: 58
+      top3_weight: 0.521013
+      top10_weight: 0.985438
+    top_holdings:
+      -
+        rank: 1
+        ticker: 4661.T
+        name: ORIENTAL LAND CO., LTD.
+        weight: 0.200000
+      -
+        rank: 2
+        ticker: 6506.T
+        name: YASKAWA ELECTRIC CORP.
+        weight: 0.183741
+      -
+        rank: 3
+        ticker: 1605.T
+        name: Inpex Corp
+        weight: 0.137272
+      -
+        rank: 4
+        ticker: 4061.T
+        name: Denka
+        weight: 0.109193
+      -
+        rank: 5
+        ticker: 4519.T
+        name: CHUGAI PHARMACEUTICAL CO., LTD.
+        weight: 0.076404
+      -
+        rank: 6
+        ticker: 8267.T
+        name: AEON CO., LTD.
+        weight: 0.069196
+      -
+        rank: 7
+        ticker: 6501.T
+        name: HITACHI, LTD.
+        weight: 0.065344
+      -
+        rank: 8
+        ticker: 7974.T
+        name: NINTENDO CO., LTD.
+        weight: 0.063813
+      -
+        rank: 9
+        ticker: 6902.T
+        name: DENSO CORP.
+        weight: 0.048655
+      -
+        rank: 10
+        ticker: 9613.T
+        name: NOMURA RESEARCH INSTITUTE, LTD.
+        weight: 0.031820
+    smallest_active_weights:
+      -
+        ticker: 6301.T
+        name: KOMATSU LTD.
+        weight: 0.001182
+      -
+        ticker: 4502.T
+        name: TAKEDA PHARMACEUTICAL CO., LTD.
+        weight: 0.013381
+      -
+        ticker: 9613.T
+        name: NOMURA RESEARCH INSTITUTE, LTD.
+        weight: 0.031820
+      -
+        ticker: 6902.T
+        name: DENSO CORP.
+        weight: 0.048655
+      -
+        ticker: 7974.T
+        name: NINTENDO CO., LTD.
+        weight: 0.063813
+    weight_buckets:
+      -
+        label: 10%以上
+        count: 4
+        weight_share: 0.630206
+        sample:
+          -
+            ticker: 4661.T
+            name: ORIENTAL LAND CO., LTD.
+            weight: 0.200000
+          -
+            ticker: 6506.T
+            name: YASKAWA ELECTRIC CORP.
+            weight: 0.183741
+          -
+            ticker: 1605.T
+            name: Inpex Corp
+            weight: 0.137272
+          -
+            ticker: 4061.T
+            name: Denka
+            weight: 0.109193
+      -
+        label: 5%-10%
+        count: 4
+        weight_share: 0.274757
+        sample:
+          -
+            ticker: 4519.T
+            name: CHUGAI PHARMACEUTICAL CO., LTD.
+            weight: 0.076404
+          -
+            ticker: 8267.T
+            name: AEON CO., LTD.
+            weight: 0.069196
+          -
+            ticker: 6501.T
+            name: HITACHI, LTD.
+            weight: 0.065344
+          -
+            ticker: 7974.T
+            name: NINTENDO CO., LTD.
+            weight: 0.063813
+      -
+        label: 1%-5%
+        count: 3
+        weight_share: 0.093856
+        sample:
+          -
+            ticker: 6902.T
+            name: DENSO CORP.
+            weight: 0.048655
+          -
+            ticker: 9613.T
+            name: NOMURA RESEARCH INSTITUTE, LTD.
+            weight: 0.031820
+          -
+            ticker: 4502.T
+            name: TAKEDA PHARMACEUTICAL CO., LTD.
+            weight: 0.013381
+      -
+        label: 1%未満
+        count: 59
+        weight_share: 0.001182
+        sample:
+          -
+            ticker: 6301.T
+            name: KOMATSU LTD.
+            weight: 0.001182
+          -
+            ticker: 1332.T
+            name: Nissui
+            weight: 0.000000
+          -
+            ticker: 5714.T
+            name: DOWA Holdings
+            weight: 0.000000
+          -
+            ticker: 7011.T
+            name: Mitsubishi Heavy Industries
+            weight: 0.000000
+          -
+            ticker: 8604.T
+            name: NOMURA HOLDINGS, INC.
+            weight: 0.000000
+    by_ticker:
+      1332.T:
+        name: Nissui
+        weight: 0.000000
+      1605.T:
+        name: Inpex Corp
+        weight: 0.137272
+      1925.T:
+        name: DAIWA HOUSE INDUSTRY CO., LTD.
+        weight: 0.000000
+      2802.T:
+        name: AJINOMOTO CO., INC.
+        weight: 0.000000
+      2914.T:
+        name: JAPAN TOBACCO INC.
+        weight: 0.000000
+      3382.T:
+        name: SEVEN & I HOLDINGS CO., LTD.
+        weight: 0.000000
+      4061.T:
+        name: Denka
+        weight: 0.109193
+      4063.T:
+        name: Shin-Etsu Chemical
+        weight: 0.000000
+      4151.T:
+        name: KYOWA KIRIN CO., LTD.
+        weight: 0.000000
+      4502.T:
+        name: TAKEDA PHARMACEUTICAL CO., LTD.
+        weight: 0.013381
+      4503.T:
+        name: ASTELLAS PHARMA INC.
+        weight: 0.000000
+      4506.T:
+        name: SUMITOMO PHARMA CO., LTD.
+        weight: 0.000000
+      4507.T:
+        name: SHIONOGI & CO., LTD.
+        weight: 0.000000
+      4519.T:
+        name: CHUGAI PHARMACEUTICAL CO., LTD.
+        weight: 0.076404
+      4523.T:
+        name: EISAI CO., LTD.
+        weight: 0.000000
+      4568.T:
+        name: DAIICHI SANKYO CO., LTD.
+        weight: 0.000000
+      4661.T:
+        name: ORIENTAL LAND CO., LTD.
+        weight: 0.200000
+      5714.T:
+        name: DOWA Holdings
+        weight: 0.000000
+      5802.T:
+        name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+        weight: 0.000000
+      5803.T:
+        name: FUJIKURA LTD.
+        weight: 0.000000
+      6301.T:
+        name: KOMATSU LTD.
+        weight: 0.001182
+      6367.T:
+        name: DAIKIN INDUSTRIES,LTD.
+        weight: 0.000000
+      6479.T:
+        name: MINEBEA MITSUMI INC.
+        weight: 0.000000
+      6501.T:
+        name: HITACHI, LTD.
+        weight: 0.065344
+      6503.T:
+        name: MITSUBISHI ELECTRIC CORP.
+        weight: 0.000000
+      6504.T:
+        name: FUJI ELECTRIC CO., LTD.
+        weight: 0.000000
+      6506.T:
+        name: YASKAWA ELECTRIC CORP.
+        weight: 0.183741
+      6594.T:
+        name: NIDEC CORP.
+        weight: 0.000000
+      6645.T:
+        name: OMRON CORP.
+        weight: 0.000000
+      6674.T:
+        name: GS YUASA CORP.
+        weight: 0.000000
+      6701.T:
+        name: NEC CORP.
+        weight: 0.000000
+      6702.T:
+        name: FUJITSU LTD.
+        weight: 0.000000
+      6723.T:
+        name: RENESAS ELECTRONICS CORP.
+        weight: 0.000000
+      6724.T:
+        name: SEIKO EPSON CORP.
+        weight: 0.000000
+      6752.T:
+        name: PANASONIC HOLDINGS CORP.
+        weight: 0.000000
+      6753.T:
+        name: SHARP CORP.
+        weight: 0.000000
+      6758.T:
+        name: SONY GROUP CORP.
+        weight: 0.000000
+      6762.T:
+        name: TDK CORP.
+        weight: 0.000000
+      6770.T:
+        name: ALPS ALPINE CO., LTD.
+        weight: 0.000000
+      6841.T:
+        name: YOKOGAWA ELECTRIC CORP.
+        weight: 0.000000
+      6857.T:
+        name: ADVANTEST CORP.
+        weight: 0.000000
+      6861.T:
+        name: KEYENCE CORP.
+        weight: 0.000000
+      6902.T:
+        name: DENSO CORP.
+        weight: 0.048655
+      6952.T:
+        name: CASIO COMPUTER CO., LTD.
+        weight: 0.000000
+      6954.T:
+        name: FANUC CORP.
+        weight: 0.000000
+      6963.T:
+        name: ROHM CO., LTD.
+        weight: 0.000000
+      6981.T:
+        name: MURATA MANUFACTURING CO., LTD.
+        weight: 0.000000
+      7011.T:
+        name: Mitsubishi Heavy Industries
+        weight: 0.000000
+      7012.T:
+        name: Kawasaki Heavy Industries
+        weight: 0.000000
+      7267.T:
+        name: HONDA MOTOR CO., LTD.
+        weight: 0.000000
+      7751.T:
+        name: CANON INC.
+        weight: 0.000000
+      7832.T:
+        name: BANDAI NAMCO HOLDINGS INC.
+        weight: 0.000000
+      7974.T:
+        name: NINTENDO CO., LTD.
+        weight: 0.063813
+      8031.T:
+        name: MITSUI & CO., LTD.
+        weight: 0.000000
+      8267.T:
+        name: AEON CO., LTD.
+        weight: 0.069196
+      8306.T:
+        name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8308.T:
+        name: RESONA HOLDINGS, INC.
+        weight: 0.000000
+      8309.T:
+        name: SUMITOMO MITSUI TRUST GROUP, INC.
+        weight: 0.000000
+      8316.T:
+        name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8411.T:
+        name: MIZUHO FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8604.T:
+        name: NOMURA HOLDINGS, INC.
+        weight: 0.000000
+      8725.T:
+        name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+        weight: 0.000000
+      8766.T:
+        name: TOKIO MARINE HOLDINGS, INC.
+        weight: 0.000000
+      8801.T:
+        name: MITSUI FUDOSAN CO., LTD.
+        weight: 0.000000
+      8802.T:
+        name: MITSUBISHI ESTATE CO., LTD.
+        weight: 0.000000
+      8830.T:
+        name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+        weight: 0.000000
+      9432.T:
+        name: NTT, INC.
+        weight: 0.000000
+      9613.T:
+        name: NOMURA RESEARCH INSTITUTE, LTD.
+        weight: 0.031820
+      9983.T:
+        name: FAST RETAILING CO., LTD.
+        weight: 0.000000
+      9984.T:
+        name: SOFTBANK GROUP CORP.
+        weight: 0.000000
+universe:
+  count: 70
+  members:
+    -
+      ticker: 1332.T
+      name: Nissui
+    -
+      ticker: 1605.T
+      name: Inpex Corp
+    -
+      ticker: 1925.T
+      name: DAIWA HOUSE INDUSTRY CO., LTD.
+    -
+      ticker: 2802.T
+      name: AJINOMOTO CO., INC.
+    -
+      ticker: 2914.T
+      name: JAPAN TOBACCO INC.
+    -
+      ticker: 3382.T
+      name: SEVEN & I HOLDINGS CO., LTD.
+    -
+      ticker: 4061.T
+      name: Denka
+    -
+      ticker: 4063.T
+      name: Shin-Etsu Chemical
+    -
+      ticker: 4151.T
+      name: KYOWA KIRIN CO., LTD.
+    -
+      ticker: 4502.T
+      name: TAKEDA PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4503.T
+      name: ASTELLAS PHARMA INC.
+    -
+      ticker: 4506.T
+      name: SUMITOMO PHARMA CO., LTD.
+    -
+      ticker: 4507.T
+      name: SHIONOGI & CO., LTD.
+    -
+      ticker: 4519.T
+      name: CHUGAI PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4523.T
+      name: EISAI CO., LTD.
+    -
+      ticker: 4568.T
+      name: DAIICHI SANKYO CO., LTD.
+    -
+      ticker: 4661.T
+      name: ORIENTAL LAND CO., LTD.
+    -
+      ticker: 5714.T
+      name: DOWA Holdings
+    -
+      ticker: 5802.T
+      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+    -
+      ticker: 5803.T
+      name: FUJIKURA LTD.
+    -
+      ticker: 6301.T
+      name: KOMATSU LTD.
+    -
+      ticker: 6367.T
+      name: DAIKIN INDUSTRIES,LTD.
+    -
+      ticker: 6479.T
+      name: MINEBEA MITSUMI INC.
+    -
+      ticker: 6501.T
+      name: HITACHI, LTD.
+    -
+      ticker: 6503.T
+      name: MITSUBISHI ELECTRIC CORP.
+    -
+      ticker: 6504.T
+      name: FUJI ELECTRIC CO., LTD.
+    -
+      ticker: 6506.T
+      name: YASKAWA ELECTRIC CORP.
+    -
+      ticker: 6594.T
+      name: NIDEC CORP.
+    -
+      ticker: 6645.T
+      name: OMRON CORP.
+    -
+      ticker: 6674.T
+      name: GS YUASA CORP.
+    -
+      ticker: 6701.T
+      name: NEC CORP.
+    -
+      ticker: 6702.T
+      name: FUJITSU LTD.
+    -
+      ticker: 6723.T
+      name: RENESAS ELECTRONICS CORP.
+    -
+      ticker: 6724.T
+      name: SEIKO EPSON CORP.
+    -
+      ticker: 6752.T
+      name: PANASONIC HOLDINGS CORP.
+    -
+      ticker: 6753.T
+      name: SHARP CORP.
+    -
+      ticker: 6758.T
+      name: SONY GROUP CORP.
+    -
+      ticker: 6762.T
+      name: TDK CORP.
+    -
+      ticker: 6770.T
+      name: ALPS ALPINE CO., LTD.
+    -
+      ticker: 6841.T
+      name: YOKOGAWA ELECTRIC CORP.
+    -
+      ticker: 6857.T
+      name: ADVANTEST CORP.
+    -
+      ticker: 6861.T
+      name: KEYENCE CORP.
+    -
+      ticker: 6902.T
+      name: DENSO CORP.
+    -
+      ticker: 6952.T
+      name: CASIO COMPUTER CO., LTD.
+    -
+      ticker: 6954.T
+      name: FANUC CORP.
+    -
+      ticker: 6963.T
+      name: ROHM CO., LTD.
+    -
+      ticker: 6981.T
+      name: MURATA MANUFACTURING CO., LTD.
+    -
+      ticker: 7011.T
+      name: Mitsubishi Heavy Industries
+    -
+      ticker: 7012.T
+      name: Kawasaki Heavy Industries
+    -
+      ticker: 7267.T
+      name: HONDA MOTOR CO., LTD.
+    -
+      ticker: 7751.T
+      name: CANON INC.
+    -
+      ticker: 7832.T
+      name: BANDAI NAMCO HOLDINGS INC.
+    -
+      ticker: 7974.T
+      name: NINTENDO CO., LTD.
+    -
+      ticker: 8031.T
+      name: MITSUI & CO., LTD.
+    -
+      ticker: 8267.T
+      name: AEON CO., LTD.
+    -
+      ticker: 8306.T
+      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+    -
+      ticker: 8308.T
+      name: RESONA HOLDINGS, INC.
+    -
+      ticker: 8309.T
+      name: SUMITOMO MITSUI TRUST GROUP, INC.
+    -
+      ticker: 8316.T
+      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+    -
+      ticker: 8411.T
+      name: MIZUHO FINANCIAL GROUP, INC.
+    -
+      ticker: 8604.T
+      name: NOMURA HOLDINGS, INC.
+    -
+      ticker: 8725.T
+      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+    -
+      ticker: 8766.T
+      name: TOKIO MARINE HOLDINGS, INC.
+    -
+      ticker: 8801.T
+      name: MITSUI FUDOSAN CO., LTD.
+    -
+      ticker: 8802.T
+      name: MITSUBISHI ESTATE CO., LTD.
+    -
+      ticker: 8830.T
+      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+    -
+      ticker: 9432.T
+      name: NTT, INC.
+    -
+      ticker: 9613.T
+      name: NOMURA RESEARCH INSTITUTE, LTD.
+    -
+      ticker: 9983.T
+      name: FAST RETAILING CO., LTD.
+    -
+      ticker: 9984.T
+      name: SOFTBANK GROUP CORP.

--- a/reports/portfolio/2019.yaml
+++ b/reports/portfolio/2019.yaml
@@ -1,437 +1,589 @@
+year: 2019
 period:
   start: 2019-01-01
   end: 2019-12-31
-universe:
-  -
-    ticker: 1332.T
-    name: Nissui
-  -
-    ticker: 4061.T
-    name: Denka
-  -
-    ticker: 5714.T
-    name: DOWA Holdings
-  -
-    ticker: 7011.T
-    name: Mitsubishi Heavy Industries
-  -
-    ticker: 8604.T
-    name: NOMURA HOLDINGS, INC.
-  -
-    ticker: 4063.T
-    name: Shin-Etsu Chemical
-  -
-    ticker: 7012.T
-    name: Kawasaki Heavy Industries
-  -
-    ticker: 1605.T
-    name: Inpex Corp
-  -
-    ticker: 4151.T
-    name: KYOWA KIRIN CO., LTD.
-  -
-    ticker: 4502.T
-    name: TAKEDA PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4503.T
-    name: ASTELLAS PHARMA INC.
-  -
-    ticker: 4506.T
-    name: SUMITOMO PHARMA CO., LTD.
-  -
-    ticker: 4507.T
-    name: SHIONOGI & CO., LTD.
-  -
-    ticker: 4519.T
-    name: CHUGAI PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4523.T
-    name: EISAI CO., LTD.
-  -
-    ticker: 4568.T
-    name: DAIICHI SANKYO CO., LTD.
-  -
-    ticker: 6479.T
-    name: MINEBEA MITSUMI INC.
-  -
-    ticker: 6501.T
-    name: HITACHI, LTD.
-  -
-    ticker: 6503.T
-    name: MITSUBISHI ELECTRIC CORP.
-  -
-    ticker: 6504.T
-    name: FUJI ELECTRIC CO., LTD.
-  -
-    ticker: 6506.T
-    name: YASKAWA ELECTRIC CORP.
-  -
-    ticker: 6594.T
-    name: NIDEC CORP.
-  -
-    ticker: 6645.T
-    name: OMRON CORP.
-  -
-    ticker: 6674.T
-    name: GS YUASA CORP.
-  -
-    ticker: 6701.T
-    name: NEC CORP.
-  -
-    ticker: 6702.T
-    name: FUJITSU LTD.
-  -
-    ticker: 6723.T
-    name: RENESAS ELECTRONICS CORP.
-  -
-    ticker: 6724.T
-    name: SEIKO EPSON CORP.
-  -
-    ticker: 6752.T
-    name: PANASONIC HOLDINGS CORP.
-  -
-    ticker: 6753.T
-    name: SHARP CORP.
-  -
-    ticker: 6758.T
-    name: SONY GROUP CORP.
-  -
-    ticker: 6762.T
-    name: TDK CORP.
-  -
-    ticker: 6770.T
-    name: ALPS ALPINE CO., LTD.
-  -
-    ticker: 6841.T
-    name: YOKOGAWA ELECTRIC CORP.
-  -
-    ticker: 6857.T
-    name: ADVANTEST CORP.
-  -
-    ticker: 6861.T
-    name: KEYENCE CORP.
-  -
-    ticker: 6902.T
-    name: DENSO CORP.
-  -
-    ticker: 6952.T
-    name: CASIO COMPUTER CO., LTD.
-  -
-    ticker: 6954.T
-    name: FANUC CORP.
-  -
-    ticker: 6963.T
-    name: ROHM CO., LTD.
-  -
-    ticker: 9984.T
-    name: SOFTBANK GROUP CORP.
-  -
-    ticker: 8306.T
-    name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-  -
-    ticker: 8316.T
-    name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-  -
-    ticker: 7974.T
-    name: NINTENDO CO., LTD.
-  -
-    ticker: 9983.T
-    name: FAST RETAILING CO., LTD.
-  -
-    ticker: 9432.T
-    name: NTT, INC.
-  -
-    ticker: 8411.T
-    name: MIZUHO FINANCIAL GROUP, INC.
-  -
-    ticker: 8766.T
-    name: TOKIO MARINE HOLDINGS, INC.
-  -
-    ticker: 8031.T
-    name: MITSUI & CO., LTD.
-  -
-    ticker: 2914.T
-    name: JAPAN TOBACCO INC.
-  -
-    ticker: 7267.T
-    name: HONDA MOTOR CO., LTD.
-  -
-    ticker: 4661.T
-    name: ORIENTAL LAND CO., LTD.
-  -
-    ticker: 6981.T
-    name: MURATA MANUFACTURING CO., LTD.
-  -
-    ticker: 6367.T
-    name: DAIKIN INDUSTRIES,LTD.
-  -
-    ticker: 8725.T
-    name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-  -
-    ticker: 3382.T
-    name: SEVEN & I HOLDINGS CO., LTD.
-  -
-    ticker: 6301.T
-    name: KOMATSU LTD.
-  -
-    ticker: 8267.T
-    name: AEON CO., LTD.
-  -
-    ticker: 8801.T
-    name: MITSUI FUDOSAN CO., LTD.
-  -
-    ticker: 2802.T
-    name: AJINOMOTO CO., INC.
-  -
-    ticker: 8802.T
-    name: MITSUBISHI ESTATE CO., LTD.
-  -
-    ticker: 5803.T
-    name: FUJIKURA LTD.
-  -
-    ticker: 7751.T
-    name: CANON INC.
-  -
-    ticker: 8308.T
-    name: RESONA HOLDINGS, INC.
-  -
-    ticker: 5802.T
-    name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-  -
-    ticker: 9613.T
-    name: NOMURA RESEARCH INSTITUTE, LTD.
-  -
-    ticker: 1925.T
-    name: DAIWA HOUSE INDUSTRY CO., LTD.
-  -
-    ticker: 7832.T
-    name: BANDAI NAMCO HOLDINGS INC.
-  -
-    ticker: 8830.T
-    name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-  -
-    ticker: 8309.T
-    name: SUMITOMO MITSUI TRUST GROUP, INC.
+conditions:
+  training_window:
+    start: 2018-04-24 09:00:00+09:00
+    end: 2018-12-31 09:00:00+09:00
+  evaluation_window:
+    start: 2019-01-04 09:00:00+09:00
+    end: 2019-12-30 09:00:00+09:00
 portfolio:
-  weights:
-    1332.T:
-      name: Nissui
-      weight: 0.101289
-    4061.T:
-      name: Denka
-      weight: 0.000000
-    5714.T:
-      name: DOWA Holdings
-      weight: 0.000000
-    7011.T:
-      name: Mitsubishi Heavy Industries
-      weight: 0.000000
-    8604.T:
-      name: NOMURA HOLDINGS, INC.
-      weight: 0.000000
-    4063.T:
-      name: Shin-Etsu Chemical
-      weight: 0.000000
-    7012.T:
-      name: Kawasaki Heavy Industries
-      weight: 0.000000
-    1605.T:
-      name: Inpex Corp
-      weight: 0.000000
-    4151.T:
-      name: KYOWA KIRIN CO., LTD.
-      weight: 0.000000
-    4502.T:
-      name: TAKEDA PHARMACEUTICAL CO., LTD.
-      weight: 0.000000
-    4503.T:
-      name: ASTELLAS PHARMA INC.
-      weight: 0.000000
-    4506.T:
-      name: SUMITOMO PHARMA CO., LTD.
-      weight: 0.200000
-    4507.T:
-      name: SHIONOGI & CO., LTD.
-      weight: 0.058072
-    4519.T:
-      name: CHUGAI PHARMACEUTICAL CO., LTD.
-      weight: 0.000000
-    4523.T:
-      name: EISAI CO., LTD.
-      weight: 0.000000
-    4568.T:
-      name: DAIICHI SANKYO CO., LTD.
-      weight: 0.000000
-    6479.T:
-      name: MINEBEA MITSUMI INC.
-      weight: 0.000000
-    6501.T:
-      name: HITACHI, LTD.
-      weight: 0.000000
-    6503.T:
-      name: MITSUBISHI ELECTRIC CORP.
-      weight: 0.000000
-    6504.T:
-      name: FUJI ELECTRIC CO., LTD.
-      weight: 0.000000
-    6506.T:
-      name: YASKAWA ELECTRIC CORP.
-      weight: 0.000000
-    6594.T:
-      name: NIDEC CORP.
-      weight: 0.000000
-    6645.T:
-      name: OMRON CORP.
-      weight: 0.000000
-    6674.T:
-      name: GS YUASA CORP.
-      weight: 0.000000
-    6701.T:
-      name: NEC CORP.
-      weight: 0.200000
-    6702.T:
-      name: FUJITSU LTD.
-      weight: 0.000000
-    6723.T:
-      name: RENESAS ELECTRONICS CORP.
-      weight: 0.000000
-    6724.T:
-      name: SEIKO EPSON CORP.
-      weight: 0.000000
-    6752.T:
-      name: PANASONIC HOLDINGS CORP.
-      weight: 0.000000
-    6753.T:
-      name: SHARP CORP.
-      weight: 0.000000
-    6758.T:
-      name: SONY GROUP CORP.
-      weight: 0.000000
-    6762.T:
-      name: TDK CORP.
-      weight: 0.000000
-    6770.T:
-      name: ALPS ALPINE CO., LTD.
-      weight: 0.000000
-    6841.T:
-      name: YOKOGAWA ELECTRIC CORP.
-      weight: 0.000000
-    6857.T:
-      name: ADVANTEST CORP.
-      weight: 0.000000
-    6861.T:
-      name: KEYENCE CORP.
-      weight: 0.000000
-    6902.T:
-      name: DENSO CORP.
-      weight: 0.000000
-    6952.T:
-      name: CASIO COMPUTER CO., LTD.
-      weight: 0.000000
-    6954.T:
-      name: FANUC CORP.
-      weight: 0.000000
-    6963.T:
-      name: ROHM CO., LTD.
-      weight: 0.000000
-    9984.T:
-      name: SOFTBANK GROUP CORP.
-      weight: 0.000000
-    8306.T:
-      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8316.T:
-      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-      weight: 0.000000
-    7974.T:
-      name: NINTENDO CO., LTD.
-      weight: 0.000000
-    9983.T:
-      name: FAST RETAILING CO., LTD.
-      weight: 0.200000
-    9432.T:
-      name: NTT, INC.
-      weight: 0.000000
-    8411.T:
-      name: MIZUHO FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8766.T:
-      name: TOKIO MARINE HOLDINGS, INC.
-      weight: 0.040640
-    8031.T:
-      name: MITSUI & CO., LTD.
-      weight: 0.000000
-    2914.T:
-      name: JAPAN TOBACCO INC.
-      weight: 0.000000
-    7267.T:
-      name: HONDA MOTOR CO., LTD.
-      weight: 0.000000
-    4661.T:
-      name: ORIENTAL LAND CO., LTD.
-      weight: 0.000000
-    6981.T:
-      name: MURATA MANUFACTURING CO., LTD.
-      weight: 0.000000
-    6367.T:
-      name: DAIKIN INDUSTRIES,LTD.
-      weight: 0.000000
-    8725.T:
-      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-      weight: 0.000000
-    3382.T:
-      name: SEVEN & I HOLDINGS CO., LTD.
-      weight: 0.000000
-    6301.T:
-      name: KOMATSU LTD.
-      weight: 0.000000
-    8267.T:
-      name: AEON CO., LTD.
-      weight: 0.000000
-    8801.T:
-      name: MITSUI FUDOSAN CO., LTD.
-      weight: 0.000000
-    2802.T:
-      name: AJINOMOTO CO., INC.
-      weight: 0.000000
-    8802.T:
-      name: MITSUBISHI ESTATE CO., LTD.
-      weight: 0.000000
-    5803.T:
-      name: FUJIKURA LTD.
-      weight: 0.000000
-    7751.T:
-      name: CANON INC.
-      weight: 0.000000
-    8308.T:
-      name: RESONA HOLDINGS, INC.
-      weight: 0.000000
-    5802.T:
-      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-      weight: 0.000000
-    9613.T:
-      name: NOMURA RESEARCH INSTITUTE, LTD.
-      weight: 0.000000
-    1925.T:
-      name: DAIWA HOUSE INDUSTRY CO., LTD.
-      weight: 0.000000
-    7832.T:
-      name: BANDAI NAMCO HOLDINGS INC.
-      weight: 0.200000
-    8830.T:
-      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-      weight: 0.000000
-    8309.T:
-      name: SUMITOMO MITSUI TRUST GROUP, INC.
-      weight: 0.000000
   risk_metrics:
     annual_return: 0.123713
     volatility: 0.165566
     sharpe_ratio: 0.747210
     max_drawdown: -0.079597
-  training_window:
-    start: 2018-04-24T09:00:00+09:00
-    end: 2018-12-31T09:00:00+09:00
-  evaluation_window:
-    start: 2019-01-04T09:00:00+09:00
-    end: 2019-12-30T09:00:00+09:00
+  allocations:
+    summary:
+      total_constituents: 70
+      invested_constituents: 7
+      zero_weight_constituents: 63
+      top3_weight: 0.600000
+      top10_weight: 1.000001
+    top_holdings:
+      -
+        rank: 1
+        ticker: 4506.T
+        name: SUMITOMO PHARMA CO., LTD.
+        weight: 0.200000
+      -
+        rank: 2
+        ticker: 6701.T
+        name: NEC CORP.
+        weight: 0.200000
+      -
+        rank: 3
+        ticker: 9983.T
+        name: FAST RETAILING CO., LTD.
+        weight: 0.200000
+      -
+        rank: 4
+        ticker: 7832.T
+        name: BANDAI NAMCO HOLDINGS INC.
+        weight: 0.200000
+      -
+        rank: 5
+        ticker: 1332.T
+        name: Nissui
+        weight: 0.101289
+      -
+        rank: 6
+        ticker: 4507.T
+        name: SHIONOGI & CO., LTD.
+        weight: 0.058072
+      -
+        rank: 7
+        ticker: 8766.T
+        name: TOKIO MARINE HOLDINGS, INC.
+        weight: 0.040640
+      -
+        rank: 8
+        ticker: 4061.T
+        name: Denka
+        weight: 0.000000
+      -
+        rank: 9
+        ticker: 5714.T
+        name: DOWA Holdings
+        weight: 0.000000
+      -
+        rank: 10
+        ticker: 7011.T
+        name: Mitsubishi Heavy Industries
+        weight: 0.000000
+    smallest_active_weights:
+      -
+        ticker: 8766.T
+        name: TOKIO MARINE HOLDINGS, INC.
+        weight: 0.040640
+      -
+        ticker: 4507.T
+        name: SHIONOGI & CO., LTD.
+        weight: 0.058072
+      -
+        ticker: 1332.T
+        name: Nissui
+        weight: 0.101289
+      -
+        ticker: 4506.T
+        name: SUMITOMO PHARMA CO., LTD.
+        weight: 0.200000
+      -
+        ticker: 6701.T
+        name: NEC CORP.
+        weight: 0.200000
+    weight_buckets:
+      -
+        label: 10%以上
+        count: 5
+        weight_share: 0.901289
+        sample:
+          -
+            ticker: 4506.T
+            name: SUMITOMO PHARMA CO., LTD.
+            weight: 0.200000
+          -
+            ticker: 6701.T
+            name: NEC CORP.
+            weight: 0.200000
+          -
+            ticker: 9983.T
+            name: FAST RETAILING CO., LTD.
+            weight: 0.200000
+          -
+            ticker: 7832.T
+            name: BANDAI NAMCO HOLDINGS INC.
+            weight: 0.200000
+          -
+            ticker: 1332.T
+            name: Nissui
+            weight: 0.101289
+      -
+        label: 5%-10%
+        count: 1
+        weight_share: 0.058072
+        sample:
+          -
+            ticker: 4507.T
+            name: SHIONOGI & CO., LTD.
+            weight: 0.058072
+      -
+        label: 1%-5%
+        count: 1
+        weight_share: 0.040640
+        sample:
+          -
+            ticker: 8766.T
+            name: TOKIO MARINE HOLDINGS, INC.
+            weight: 0.040640
+      -
+        label: 1%未満
+        count: 63
+        weight_share: 0.000000
+        sample:
+          -
+            ticker: 4061.T
+            name: Denka
+            weight: 0.000000
+          -
+            ticker: 5714.T
+            name: DOWA Holdings
+            weight: 0.000000
+          -
+            ticker: 7011.T
+            name: Mitsubishi Heavy Industries
+            weight: 0.000000
+          -
+            ticker: 8604.T
+            name: NOMURA HOLDINGS, INC.
+            weight: 0.000000
+          -
+            ticker: 4063.T
+            name: Shin-Etsu Chemical
+            weight: 0.000000
+    by_ticker:
+      1332.T:
+        name: Nissui
+        weight: 0.101289
+      1605.T:
+        name: Inpex Corp
+        weight: 0.000000
+      1925.T:
+        name: DAIWA HOUSE INDUSTRY CO., LTD.
+        weight: 0.000000
+      2802.T:
+        name: AJINOMOTO CO., INC.
+        weight: 0.000000
+      2914.T:
+        name: JAPAN TOBACCO INC.
+        weight: 0.000000
+      3382.T:
+        name: SEVEN & I HOLDINGS CO., LTD.
+        weight: 0.000000
+      4061.T:
+        name: Denka
+        weight: 0.000000
+      4063.T:
+        name: Shin-Etsu Chemical
+        weight: 0.000000
+      4151.T:
+        name: KYOWA KIRIN CO., LTD.
+        weight: 0.000000
+      4502.T:
+        name: TAKEDA PHARMACEUTICAL CO., LTD.
+        weight: 0.000000
+      4503.T:
+        name: ASTELLAS PHARMA INC.
+        weight: 0.000000
+      4506.T:
+        name: SUMITOMO PHARMA CO., LTD.
+        weight: 0.200000
+      4507.T:
+        name: SHIONOGI & CO., LTD.
+        weight: 0.058072
+      4519.T:
+        name: CHUGAI PHARMACEUTICAL CO., LTD.
+        weight: 0.000000
+      4523.T:
+        name: EISAI CO., LTD.
+        weight: 0.000000
+      4568.T:
+        name: DAIICHI SANKYO CO., LTD.
+        weight: 0.000000
+      4661.T:
+        name: ORIENTAL LAND CO., LTD.
+        weight: 0.000000
+      5714.T:
+        name: DOWA Holdings
+        weight: 0.000000
+      5802.T:
+        name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+        weight: 0.000000
+      5803.T:
+        name: FUJIKURA LTD.
+        weight: 0.000000
+      6301.T:
+        name: KOMATSU LTD.
+        weight: 0.000000
+      6367.T:
+        name: DAIKIN INDUSTRIES,LTD.
+        weight: 0.000000
+      6479.T:
+        name: MINEBEA MITSUMI INC.
+        weight: 0.000000
+      6501.T:
+        name: HITACHI, LTD.
+        weight: 0.000000
+      6503.T:
+        name: MITSUBISHI ELECTRIC CORP.
+        weight: 0.000000
+      6504.T:
+        name: FUJI ELECTRIC CO., LTD.
+        weight: 0.000000
+      6506.T:
+        name: YASKAWA ELECTRIC CORP.
+        weight: 0.000000
+      6594.T:
+        name: NIDEC CORP.
+        weight: 0.000000
+      6645.T:
+        name: OMRON CORP.
+        weight: 0.000000
+      6674.T:
+        name: GS YUASA CORP.
+        weight: 0.000000
+      6701.T:
+        name: NEC CORP.
+        weight: 0.200000
+      6702.T:
+        name: FUJITSU LTD.
+        weight: 0.000000
+      6723.T:
+        name: RENESAS ELECTRONICS CORP.
+        weight: 0.000000
+      6724.T:
+        name: SEIKO EPSON CORP.
+        weight: 0.000000
+      6752.T:
+        name: PANASONIC HOLDINGS CORP.
+        weight: 0.000000
+      6753.T:
+        name: SHARP CORP.
+        weight: 0.000000
+      6758.T:
+        name: SONY GROUP CORP.
+        weight: 0.000000
+      6762.T:
+        name: TDK CORP.
+        weight: 0.000000
+      6770.T:
+        name: ALPS ALPINE CO., LTD.
+        weight: 0.000000
+      6841.T:
+        name: YOKOGAWA ELECTRIC CORP.
+        weight: 0.000000
+      6857.T:
+        name: ADVANTEST CORP.
+        weight: 0.000000
+      6861.T:
+        name: KEYENCE CORP.
+        weight: 0.000000
+      6902.T:
+        name: DENSO CORP.
+        weight: 0.000000
+      6952.T:
+        name: CASIO COMPUTER CO., LTD.
+        weight: 0.000000
+      6954.T:
+        name: FANUC CORP.
+        weight: 0.000000
+      6963.T:
+        name: ROHM CO., LTD.
+        weight: 0.000000
+      6981.T:
+        name: MURATA MANUFACTURING CO., LTD.
+        weight: 0.000000
+      7011.T:
+        name: Mitsubishi Heavy Industries
+        weight: 0.000000
+      7012.T:
+        name: Kawasaki Heavy Industries
+        weight: 0.000000
+      7267.T:
+        name: HONDA MOTOR CO., LTD.
+        weight: 0.000000
+      7751.T:
+        name: CANON INC.
+        weight: 0.000000
+      7832.T:
+        name: BANDAI NAMCO HOLDINGS INC.
+        weight: 0.200000
+      7974.T:
+        name: NINTENDO CO., LTD.
+        weight: 0.000000
+      8031.T:
+        name: MITSUI & CO., LTD.
+        weight: 0.000000
+      8267.T:
+        name: AEON CO., LTD.
+        weight: 0.000000
+      8306.T:
+        name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8308.T:
+        name: RESONA HOLDINGS, INC.
+        weight: 0.000000
+      8309.T:
+        name: SUMITOMO MITSUI TRUST GROUP, INC.
+        weight: 0.000000
+      8316.T:
+        name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8411.T:
+        name: MIZUHO FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8604.T:
+        name: NOMURA HOLDINGS, INC.
+        weight: 0.000000
+      8725.T:
+        name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+        weight: 0.000000
+      8766.T:
+        name: TOKIO MARINE HOLDINGS, INC.
+        weight: 0.040640
+      8801.T:
+        name: MITSUI FUDOSAN CO., LTD.
+        weight: 0.000000
+      8802.T:
+        name: MITSUBISHI ESTATE CO., LTD.
+        weight: 0.000000
+      8830.T:
+        name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+        weight: 0.000000
+      9432.T:
+        name: NTT, INC.
+        weight: 0.000000
+      9613.T:
+        name: NOMURA RESEARCH INSTITUTE, LTD.
+        weight: 0.000000
+      9983.T:
+        name: FAST RETAILING CO., LTD.
+        weight: 0.200000
+      9984.T:
+        name: SOFTBANK GROUP CORP.
+        weight: 0.000000
+universe:
+  count: 70
+  members:
+    -
+      ticker: 1332.T
+      name: Nissui
+    -
+      ticker: 1605.T
+      name: Inpex Corp
+    -
+      ticker: 1925.T
+      name: DAIWA HOUSE INDUSTRY CO., LTD.
+    -
+      ticker: 2802.T
+      name: AJINOMOTO CO., INC.
+    -
+      ticker: 2914.T
+      name: JAPAN TOBACCO INC.
+    -
+      ticker: 3382.T
+      name: SEVEN & I HOLDINGS CO., LTD.
+    -
+      ticker: 4061.T
+      name: Denka
+    -
+      ticker: 4063.T
+      name: Shin-Etsu Chemical
+    -
+      ticker: 4151.T
+      name: KYOWA KIRIN CO., LTD.
+    -
+      ticker: 4502.T
+      name: TAKEDA PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4503.T
+      name: ASTELLAS PHARMA INC.
+    -
+      ticker: 4506.T
+      name: SUMITOMO PHARMA CO., LTD.
+    -
+      ticker: 4507.T
+      name: SHIONOGI & CO., LTD.
+    -
+      ticker: 4519.T
+      name: CHUGAI PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4523.T
+      name: EISAI CO., LTD.
+    -
+      ticker: 4568.T
+      name: DAIICHI SANKYO CO., LTD.
+    -
+      ticker: 4661.T
+      name: ORIENTAL LAND CO., LTD.
+    -
+      ticker: 5714.T
+      name: DOWA Holdings
+    -
+      ticker: 5802.T
+      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+    -
+      ticker: 5803.T
+      name: FUJIKURA LTD.
+    -
+      ticker: 6301.T
+      name: KOMATSU LTD.
+    -
+      ticker: 6367.T
+      name: DAIKIN INDUSTRIES,LTD.
+    -
+      ticker: 6479.T
+      name: MINEBEA MITSUMI INC.
+    -
+      ticker: 6501.T
+      name: HITACHI, LTD.
+    -
+      ticker: 6503.T
+      name: MITSUBISHI ELECTRIC CORP.
+    -
+      ticker: 6504.T
+      name: FUJI ELECTRIC CO., LTD.
+    -
+      ticker: 6506.T
+      name: YASKAWA ELECTRIC CORP.
+    -
+      ticker: 6594.T
+      name: NIDEC CORP.
+    -
+      ticker: 6645.T
+      name: OMRON CORP.
+    -
+      ticker: 6674.T
+      name: GS YUASA CORP.
+    -
+      ticker: 6701.T
+      name: NEC CORP.
+    -
+      ticker: 6702.T
+      name: FUJITSU LTD.
+    -
+      ticker: 6723.T
+      name: RENESAS ELECTRONICS CORP.
+    -
+      ticker: 6724.T
+      name: SEIKO EPSON CORP.
+    -
+      ticker: 6752.T
+      name: PANASONIC HOLDINGS CORP.
+    -
+      ticker: 6753.T
+      name: SHARP CORP.
+    -
+      ticker: 6758.T
+      name: SONY GROUP CORP.
+    -
+      ticker: 6762.T
+      name: TDK CORP.
+    -
+      ticker: 6770.T
+      name: ALPS ALPINE CO., LTD.
+    -
+      ticker: 6841.T
+      name: YOKOGAWA ELECTRIC CORP.
+    -
+      ticker: 6857.T
+      name: ADVANTEST CORP.
+    -
+      ticker: 6861.T
+      name: KEYENCE CORP.
+    -
+      ticker: 6902.T
+      name: DENSO CORP.
+    -
+      ticker: 6952.T
+      name: CASIO COMPUTER CO., LTD.
+    -
+      ticker: 6954.T
+      name: FANUC CORP.
+    -
+      ticker: 6963.T
+      name: ROHM CO., LTD.
+    -
+      ticker: 6981.T
+      name: MURATA MANUFACTURING CO., LTD.
+    -
+      ticker: 7011.T
+      name: Mitsubishi Heavy Industries
+    -
+      ticker: 7012.T
+      name: Kawasaki Heavy Industries
+    -
+      ticker: 7267.T
+      name: HONDA MOTOR CO., LTD.
+    -
+      ticker: 7751.T
+      name: CANON INC.
+    -
+      ticker: 7832.T
+      name: BANDAI NAMCO HOLDINGS INC.
+    -
+      ticker: 7974.T
+      name: NINTENDO CO., LTD.
+    -
+      ticker: 8031.T
+      name: MITSUI & CO., LTD.
+    -
+      ticker: 8267.T
+      name: AEON CO., LTD.
+    -
+      ticker: 8306.T
+      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+    -
+      ticker: 8308.T
+      name: RESONA HOLDINGS, INC.
+    -
+      ticker: 8309.T
+      name: SUMITOMO MITSUI TRUST GROUP, INC.
+    -
+      ticker: 8316.T
+      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+    -
+      ticker: 8411.T
+      name: MIZUHO FINANCIAL GROUP, INC.
+    -
+      ticker: 8604.T
+      name: NOMURA HOLDINGS, INC.
+    -
+      ticker: 8725.T
+      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+    -
+      ticker: 8766.T
+      name: TOKIO MARINE HOLDINGS, INC.
+    -
+      ticker: 8801.T
+      name: MITSUI FUDOSAN CO., LTD.
+    -
+      ticker: 8802.T
+      name: MITSUBISHI ESTATE CO., LTD.
+    -
+      ticker: 8830.T
+      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+    -
+      ticker: 9432.T
+      name: NTT, INC.
+    -
+      ticker: 9613.T
+      name: NOMURA RESEARCH INSTITUTE, LTD.
+    -
+      ticker: 9983.T
+      name: FAST RETAILING CO., LTD.
+    -
+      ticker: 9984.T
+      name: SOFTBANK GROUP CORP.

--- a/reports/portfolio/2020.yaml
+++ b/reports/portfolio/2020.yaml
@@ -1,437 +1,605 @@
+year: 2020
 period:
   start: 2020-01-01
   end: 2020-12-31
-universe:
-  -
-    ticker: 1332.T
-    name: Nissui
-  -
-    ticker: 4061.T
-    name: Denka
-  -
-    ticker: 5714.T
-    name: DOWA Holdings
-  -
-    ticker: 7011.T
-    name: Mitsubishi Heavy Industries
-  -
-    ticker: 8604.T
-    name: NOMURA HOLDINGS, INC.
-  -
-    ticker: 4063.T
-    name: Shin-Etsu Chemical
-  -
-    ticker: 7012.T
-    name: Kawasaki Heavy Industries
-  -
-    ticker: 1605.T
-    name: Inpex Corp
-  -
-    ticker: 4151.T
-    name: KYOWA KIRIN CO., LTD.
-  -
-    ticker: 4502.T
-    name: TAKEDA PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4503.T
-    name: ASTELLAS PHARMA INC.
-  -
-    ticker: 4506.T
-    name: SUMITOMO PHARMA CO., LTD.
-  -
-    ticker: 4507.T
-    name: SHIONOGI & CO., LTD.
-  -
-    ticker: 4519.T
-    name: CHUGAI PHARMACEUTICAL CO., LTD.
-  -
-    ticker: 4523.T
-    name: EISAI CO., LTD.
-  -
-    ticker: 4568.T
-    name: DAIICHI SANKYO CO., LTD.
-  -
-    ticker: 6479.T
-    name: MINEBEA MITSUMI INC.
-  -
-    ticker: 6501.T
-    name: HITACHI, LTD.
-  -
-    ticker: 6503.T
-    name: MITSUBISHI ELECTRIC CORP.
-  -
-    ticker: 6504.T
-    name: FUJI ELECTRIC CO., LTD.
-  -
-    ticker: 6506.T
-    name: YASKAWA ELECTRIC CORP.
-  -
-    ticker: 6594.T
-    name: NIDEC CORP.
-  -
-    ticker: 6645.T
-    name: OMRON CORP.
-  -
-    ticker: 6674.T
-    name: GS YUASA CORP.
-  -
-    ticker: 6701.T
-    name: NEC CORP.
-  -
-    ticker: 6702.T
-    name: FUJITSU LTD.
-  -
-    ticker: 6723.T
-    name: RENESAS ELECTRONICS CORP.
-  -
-    ticker: 6724.T
-    name: SEIKO EPSON CORP.
-  -
-    ticker: 6752.T
-    name: PANASONIC HOLDINGS CORP.
-  -
-    ticker: 6753.T
-    name: SHARP CORP.
-  -
-    ticker: 6758.T
-    name: SONY GROUP CORP.
-  -
-    ticker: 6762.T
-    name: TDK CORP.
-  -
-    ticker: 6770.T
-    name: ALPS ALPINE CO., LTD.
-  -
-    ticker: 6841.T
-    name: YOKOGAWA ELECTRIC CORP.
-  -
-    ticker: 6857.T
-    name: ADVANTEST CORP.
-  -
-    ticker: 6861.T
-    name: KEYENCE CORP.
-  -
-    ticker: 6902.T
-    name: DENSO CORP.
-  -
-    ticker: 6952.T
-    name: CASIO COMPUTER CO., LTD.
-  -
-    ticker: 6954.T
-    name: FANUC CORP.
-  -
-    ticker: 6963.T
-    name: ROHM CO., LTD.
-  -
-    ticker: 9984.T
-    name: SOFTBANK GROUP CORP.
-  -
-    ticker: 8306.T
-    name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-  -
-    ticker: 8316.T
-    name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-  -
-    ticker: 7974.T
-    name: NINTENDO CO., LTD.
-  -
-    ticker: 9983.T
-    name: FAST RETAILING CO., LTD.
-  -
-    ticker: 9432.T
-    name: NTT, INC.
-  -
-    ticker: 8411.T
-    name: MIZUHO FINANCIAL GROUP, INC.
-  -
-    ticker: 8766.T
-    name: TOKIO MARINE HOLDINGS, INC.
-  -
-    ticker: 8031.T
-    name: MITSUI & CO., LTD.
-  -
-    ticker: 2914.T
-    name: JAPAN TOBACCO INC.
-  -
-    ticker: 7267.T
-    name: HONDA MOTOR CO., LTD.
-  -
-    ticker: 4661.T
-    name: ORIENTAL LAND CO., LTD.
-  -
-    ticker: 6981.T
-    name: MURATA MANUFACTURING CO., LTD.
-  -
-    ticker: 6367.T
-    name: DAIKIN INDUSTRIES,LTD.
-  -
-    ticker: 8725.T
-    name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-  -
-    ticker: 3382.T
-    name: SEVEN & I HOLDINGS CO., LTD.
-  -
-    ticker: 6301.T
-    name: KOMATSU LTD.
-  -
-    ticker: 8267.T
-    name: AEON CO., LTD.
-  -
-    ticker: 8801.T
-    name: MITSUI FUDOSAN CO., LTD.
-  -
-    ticker: 2802.T
-    name: AJINOMOTO CO., INC.
-  -
-    ticker: 8802.T
-    name: MITSUBISHI ESTATE CO., LTD.
-  -
-    ticker: 5803.T
-    name: FUJIKURA LTD.
-  -
-    ticker: 7751.T
-    name: CANON INC.
-  -
-    ticker: 8308.T
-    name: RESONA HOLDINGS, INC.
-  -
-    ticker: 5802.T
-    name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-  -
-    ticker: 9613.T
-    name: NOMURA RESEARCH INSTITUTE, LTD.
-  -
-    ticker: 1925.T
-    name: DAIWA HOUSE INDUSTRY CO., LTD.
-  -
-    ticker: 7832.T
-    name: BANDAI NAMCO HOLDINGS INC.
-  -
-    ticker: 8830.T
-    name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-  -
-    ticker: 8309.T
-    name: SUMITOMO MITSUI TRUST GROUP, INC.
+conditions:
+  training_window:
+    start: 2019-04-24 09:00:00+09:00
+    end: 2019-12-30 09:00:00+09:00
+  evaluation_window:
+    start: 2020-01-06 09:00:00+09:00
+    end: 2020-12-30 09:00:00+09:00
 portfolio:
-  weights:
-    1332.T:
-      name: Nissui
-      weight: 0.000000
-    4061.T:
-      name: Denka
-      weight: 0.000000
-    5714.T:
-      name: DOWA Holdings
-      weight: 0.000000
-    7011.T:
-      name: Mitsubishi Heavy Industries
-      weight: 0.000000
-    8604.T:
-      name: NOMURA HOLDINGS, INC.
-      weight: 0.003953
-    4063.T:
-      name: Shin-Etsu Chemical
-      weight: 0.000000
-    7012.T:
-      name: Kawasaki Heavy Industries
-      weight: 0.000000
-    1605.T:
-      name: Inpex Corp
-      weight: 0.000000
-    4151.T:
-      name: KYOWA KIRIN CO., LTD.
-      weight: 0.000000
-    4502.T:
-      name: TAKEDA PHARMACEUTICAL CO., LTD.
-      weight: 0.000000
-    4503.T:
-      name: ASTELLAS PHARMA INC.
-      weight: 0.039847
-    4506.T:
-      name: SUMITOMO PHARMA CO., LTD.
-      weight: 0.000000
-    4507.T:
-      name: SHIONOGI & CO., LTD.
-      weight: 0.000000
-    4519.T:
-      name: CHUGAI PHARMACEUTICAL CO., LTD.
-      weight: 0.200000
-    4523.T:
-      name: EISAI CO., LTD.
-      weight: 0.000000
-    4568.T:
-      name: DAIICHI SANKYO CO., LTD.
-      weight: 0.067659
-    6479.T:
-      name: MINEBEA MITSUMI INC.
-      weight: 0.000000
-    6501.T:
-      name: HITACHI, LTD.
-      weight: 0.000000
-    6503.T:
-      name: MITSUBISHI ELECTRIC CORP.
-      weight: 0.000000
-    6504.T:
-      name: FUJI ELECTRIC CO., LTD.
-      weight: 0.000000
-    6506.T:
-      name: YASKAWA ELECTRIC CORP.
-      weight: 0.000000
-    6594.T:
-      name: NIDEC CORP.
-      weight: 0.000000
-    6645.T:
-      name: OMRON CORP.
-      weight: 0.000000
-    6674.T:
-      name: GS YUASA CORP.
-      weight: 0.000000
-    6701.T:
-      name: NEC CORP.
-      weight: 0.000000
-    6702.T:
-      name: FUJITSU LTD.
-      weight: 0.097375
-    6723.T:
-      name: RENESAS ELECTRONICS CORP.
-      weight: 0.000000
-    6724.T:
-      name: SEIKO EPSON CORP.
-      weight: 0.000000
-    6752.T:
-      name: PANASONIC HOLDINGS CORP.
-      weight: 0.000000
-    6753.T:
-      name: SHARP CORP.
-      weight: 0.014477
-    6758.T:
-      name: SONY GROUP CORP.
-      weight: 0.062632
-    6762.T:
-      name: TDK CORP.
-      weight: 0.000000
-    6770.T:
-      name: ALPS ALPINE CO., LTD.
-      weight: 0.000000
-    6841.T:
-      name: YOKOGAWA ELECTRIC CORP.
-      weight: 0.000000
-    6857.T:
-      name: ADVANTEST CORP.
-      weight: 0.079548
-    6861.T:
-      name: KEYENCE CORP.
-      weight: 0.000000
-    6902.T:
-      name: DENSO CORP.
-      weight: 0.000000
-    6952.T:
-      name: CASIO COMPUTER CO., LTD.
-      weight: 0.200000
-    6954.T:
-      name: FANUC CORP.
-      weight: 0.000000
-    6963.T:
-      name: ROHM CO., LTD.
-      weight: 0.000000
-    9984.T:
-      name: SOFTBANK GROUP CORP.
-      weight: 0.000000
-    8306.T:
-      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8316.T:
-      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
-      weight: 0.000000
-    7974.T:
-      name: NINTENDO CO., LTD.
-      weight: 0.018809
-    9983.T:
-      name: FAST RETAILING CO., LTD.
-      weight: 0.000000
-    9432.T:
-      name: NTT, INC.
-      weight: 0.157997
-    8411.T:
-      name: MIZUHO FINANCIAL GROUP, INC.
-      weight: 0.000000
-    8766.T:
-      name: TOKIO MARINE HOLDINGS, INC.
-      weight: 0.000000
-    8031.T:
-      name: MITSUI & CO., LTD.
-      weight: 0.000000
-    2914.T:
-      name: JAPAN TOBACCO INC.
-      weight: 0.000000
-    7267.T:
-      name: HONDA MOTOR CO., LTD.
-      weight: 0.000000
-    4661.T:
-      name: ORIENTAL LAND CO., LTD.
-      weight: 0.000000
-    6981.T:
-      name: MURATA MANUFACTURING CO., LTD.
-      weight: 0.000000
-    6367.T:
-      name: DAIKIN INDUSTRIES,LTD.
-      weight: 0.000000
-    8725.T:
-      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
-      weight: 0.000000
-    3382.T:
-      name: SEVEN & I HOLDINGS CO., LTD.
-      weight: 0.000000
-    6301.T:
-      name: KOMATSU LTD.
-      weight: 0.000000
-    8267.T:
-      name: AEON CO., LTD.
-      weight: 0.000000
-    8801.T:
-      name: MITSUI FUDOSAN CO., LTD.
-      weight: 0.000000
-    2802.T:
-      name: AJINOMOTO CO., INC.
-      weight: 0.000000
-    8802.T:
-      name: MITSUBISHI ESTATE CO., LTD.
-      weight: 0.000000
-    5803.T:
-      name: FUJIKURA LTD.
-      weight: 0.000000
-    7751.T:
-      name: CANON INC.
-      weight: 0.000000
-    8308.T:
-      name: RESONA HOLDINGS, INC.
-      weight: 0.000000
-    5802.T:
-      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
-      weight: 0.000000
-    9613.T:
-      name: NOMURA RESEARCH INSTITUTE, LTD.
-      weight: 0.000000
-    1925.T:
-      name: DAIWA HOUSE INDUSTRY CO., LTD.
-      weight: 0.000000
-    7832.T:
-      name: BANDAI NAMCO HOLDINGS INC.
-      weight: 0.057703
-    8830.T:
-      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
-      weight: 0.000000
-    8309.T:
-      name: SUMITOMO MITSUI TRUST GROUP, INC.
-      weight: 0.000000
   risk_metrics:
     annual_return: 0.258528
     volatility: 0.240779
     sharpe_ratio: 1.073713
     max_drawdown: -0.257515
-  training_window:
-    start: 2019-04-24T09:00:00+09:00
-    end: 2019-12-30T09:00:00+09:00
-  evaluation_window:
-    start: 2020-01-06T09:00:00+09:00
-    end: 2020-12-30T09:00:00+09:00
+  allocations:
+    summary:
+      total_constituents: 70
+      invested_constituents: 12
+      zero_weight_constituents: 58
+      top3_weight: 0.557997
+      top10_weight: 0.981570
+    top_holdings:
+      -
+        rank: 1
+        ticker: 4519.T
+        name: CHUGAI PHARMACEUTICAL CO., LTD.
+        weight: 0.200000
+      -
+        rank: 2
+        ticker: 6952.T
+        name: CASIO COMPUTER CO., LTD.
+        weight: 0.200000
+      -
+        rank: 3
+        ticker: 9432.T
+        name: NTT, INC.
+        weight: 0.157997
+      -
+        rank: 4
+        ticker: 6702.T
+        name: FUJITSU LTD.
+        weight: 0.097375
+      -
+        rank: 5
+        ticker: 6857.T
+        name: ADVANTEST CORP.
+        weight: 0.079548
+      -
+        rank: 6
+        ticker: 4568.T
+        name: DAIICHI SANKYO CO., LTD.
+        weight: 0.067659
+      -
+        rank: 7
+        ticker: 6758.T
+        name: SONY GROUP CORP.
+        weight: 0.062632
+      -
+        rank: 8
+        ticker: 7832.T
+        name: BANDAI NAMCO HOLDINGS INC.
+        weight: 0.057703
+      -
+        rank: 9
+        ticker: 4503.T
+        name: ASTELLAS PHARMA INC.
+        weight: 0.039847
+      -
+        rank: 10
+        ticker: 7974.T
+        name: NINTENDO CO., LTD.
+        weight: 0.018809
+    smallest_active_weights:
+      -
+        ticker: 8604.T
+        name: NOMURA HOLDINGS, INC.
+        weight: 0.003953
+      -
+        ticker: 6753.T
+        name: SHARP CORP.
+        weight: 0.014477
+      -
+        ticker: 7974.T
+        name: NINTENDO CO., LTD.
+        weight: 0.018809
+      -
+        ticker: 4503.T
+        name: ASTELLAS PHARMA INC.
+        weight: 0.039847
+      -
+        ticker: 7832.T
+        name: BANDAI NAMCO HOLDINGS INC.
+        weight: 0.057703
+    weight_buckets:
+      -
+        label: 10%以上
+        count: 3
+        weight_share: 0.557997
+        sample:
+          -
+            ticker: 4519.T
+            name: CHUGAI PHARMACEUTICAL CO., LTD.
+            weight: 0.200000
+          -
+            ticker: 6952.T
+            name: CASIO COMPUTER CO., LTD.
+            weight: 0.200000
+          -
+            ticker: 9432.T
+            name: NTT, INC.
+            weight: 0.157997
+      -
+        label: 5%-10%
+        count: 5
+        weight_share: 0.364917
+        sample:
+          -
+            ticker: 6702.T
+            name: FUJITSU LTD.
+            weight: 0.097375
+          -
+            ticker: 6857.T
+            name: ADVANTEST CORP.
+            weight: 0.079548
+          -
+            ticker: 4568.T
+            name: DAIICHI SANKYO CO., LTD.
+            weight: 0.067659
+          -
+            ticker: 6758.T
+            name: SONY GROUP CORP.
+            weight: 0.062632
+          -
+            ticker: 7832.T
+            name: BANDAI NAMCO HOLDINGS INC.
+            weight: 0.057703
+      -
+        label: 1%-5%
+        count: 3
+        weight_share: 0.073133
+        sample:
+          -
+            ticker: 4503.T
+            name: ASTELLAS PHARMA INC.
+            weight: 0.039847
+          -
+            ticker: 7974.T
+            name: NINTENDO CO., LTD.
+            weight: 0.018809
+          -
+            ticker: 6753.T
+            name: SHARP CORP.
+            weight: 0.014477
+      -
+        label: 1%未満
+        count: 59
+        weight_share: 0.003953
+        sample:
+          -
+            ticker: 8604.T
+            name: NOMURA HOLDINGS, INC.
+            weight: 0.003953
+          -
+            ticker: 1332.T
+            name: Nissui
+            weight: 0.000000
+          -
+            ticker: 4061.T
+            name: Denka
+            weight: 0.000000
+          -
+            ticker: 5714.T
+            name: DOWA Holdings
+            weight: 0.000000
+          -
+            ticker: 7011.T
+            name: Mitsubishi Heavy Industries
+            weight: 0.000000
+    by_ticker:
+      1332.T:
+        name: Nissui
+        weight: 0.000000
+      1605.T:
+        name: Inpex Corp
+        weight: 0.000000
+      1925.T:
+        name: DAIWA HOUSE INDUSTRY CO., LTD.
+        weight: 0.000000
+      2802.T:
+        name: AJINOMOTO CO., INC.
+        weight: 0.000000
+      2914.T:
+        name: JAPAN TOBACCO INC.
+        weight: 0.000000
+      3382.T:
+        name: SEVEN & I HOLDINGS CO., LTD.
+        weight: 0.000000
+      4061.T:
+        name: Denka
+        weight: 0.000000
+      4063.T:
+        name: Shin-Etsu Chemical
+        weight: 0.000000
+      4151.T:
+        name: KYOWA KIRIN CO., LTD.
+        weight: 0.000000
+      4502.T:
+        name: TAKEDA PHARMACEUTICAL CO., LTD.
+        weight: 0.000000
+      4503.T:
+        name: ASTELLAS PHARMA INC.
+        weight: 0.039847
+      4506.T:
+        name: SUMITOMO PHARMA CO., LTD.
+        weight: 0.000000
+      4507.T:
+        name: SHIONOGI & CO., LTD.
+        weight: 0.000000
+      4519.T:
+        name: CHUGAI PHARMACEUTICAL CO., LTD.
+        weight: 0.200000
+      4523.T:
+        name: EISAI CO., LTD.
+        weight: 0.000000
+      4568.T:
+        name: DAIICHI SANKYO CO., LTD.
+        weight: 0.067659
+      4661.T:
+        name: ORIENTAL LAND CO., LTD.
+        weight: 0.000000
+      5714.T:
+        name: DOWA Holdings
+        weight: 0.000000
+      5802.T:
+        name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+        weight: 0.000000
+      5803.T:
+        name: FUJIKURA LTD.
+        weight: 0.000000
+      6301.T:
+        name: KOMATSU LTD.
+        weight: 0.000000
+      6367.T:
+        name: DAIKIN INDUSTRIES,LTD.
+        weight: 0.000000
+      6479.T:
+        name: MINEBEA MITSUMI INC.
+        weight: 0.000000
+      6501.T:
+        name: HITACHI, LTD.
+        weight: 0.000000
+      6503.T:
+        name: MITSUBISHI ELECTRIC CORP.
+        weight: 0.000000
+      6504.T:
+        name: FUJI ELECTRIC CO., LTD.
+        weight: 0.000000
+      6506.T:
+        name: YASKAWA ELECTRIC CORP.
+        weight: 0.000000
+      6594.T:
+        name: NIDEC CORP.
+        weight: 0.000000
+      6645.T:
+        name: OMRON CORP.
+        weight: 0.000000
+      6674.T:
+        name: GS YUASA CORP.
+        weight: 0.000000
+      6701.T:
+        name: NEC CORP.
+        weight: 0.000000
+      6702.T:
+        name: FUJITSU LTD.
+        weight: 0.097375
+      6723.T:
+        name: RENESAS ELECTRONICS CORP.
+        weight: 0.000000
+      6724.T:
+        name: SEIKO EPSON CORP.
+        weight: 0.000000
+      6752.T:
+        name: PANASONIC HOLDINGS CORP.
+        weight: 0.000000
+      6753.T:
+        name: SHARP CORP.
+        weight: 0.014477
+      6758.T:
+        name: SONY GROUP CORP.
+        weight: 0.062632
+      6762.T:
+        name: TDK CORP.
+        weight: 0.000000
+      6770.T:
+        name: ALPS ALPINE CO., LTD.
+        weight: 0.000000
+      6841.T:
+        name: YOKOGAWA ELECTRIC CORP.
+        weight: 0.000000
+      6857.T:
+        name: ADVANTEST CORP.
+        weight: 0.079548
+      6861.T:
+        name: KEYENCE CORP.
+        weight: 0.000000
+      6902.T:
+        name: DENSO CORP.
+        weight: 0.000000
+      6952.T:
+        name: CASIO COMPUTER CO., LTD.
+        weight: 0.200000
+      6954.T:
+        name: FANUC CORP.
+        weight: 0.000000
+      6963.T:
+        name: ROHM CO., LTD.
+        weight: 0.000000
+      6981.T:
+        name: MURATA MANUFACTURING CO., LTD.
+        weight: 0.000000
+      7011.T:
+        name: Mitsubishi Heavy Industries
+        weight: 0.000000
+      7012.T:
+        name: Kawasaki Heavy Industries
+        weight: 0.000000
+      7267.T:
+        name: HONDA MOTOR CO., LTD.
+        weight: 0.000000
+      7751.T:
+        name: CANON INC.
+        weight: 0.000000
+      7832.T:
+        name: BANDAI NAMCO HOLDINGS INC.
+        weight: 0.057703
+      7974.T:
+        name: NINTENDO CO., LTD.
+        weight: 0.018809
+      8031.T:
+        name: MITSUI & CO., LTD.
+        weight: 0.000000
+      8267.T:
+        name: AEON CO., LTD.
+        weight: 0.000000
+      8306.T:
+        name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8308.T:
+        name: RESONA HOLDINGS, INC.
+        weight: 0.000000
+      8309.T:
+        name: SUMITOMO MITSUI TRUST GROUP, INC.
+        weight: 0.000000
+      8316.T:
+        name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8411.T:
+        name: MIZUHO FINANCIAL GROUP, INC.
+        weight: 0.000000
+      8604.T:
+        name: NOMURA HOLDINGS, INC.
+        weight: 0.003953
+      8725.T:
+        name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+        weight: 0.000000
+      8766.T:
+        name: TOKIO MARINE HOLDINGS, INC.
+        weight: 0.000000
+      8801.T:
+        name: MITSUI FUDOSAN CO., LTD.
+        weight: 0.000000
+      8802.T:
+        name: MITSUBISHI ESTATE CO., LTD.
+        weight: 0.000000
+      8830.T:
+        name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+        weight: 0.000000
+      9432.T:
+        name: NTT, INC.
+        weight: 0.157997
+      9613.T:
+        name: NOMURA RESEARCH INSTITUTE, LTD.
+        weight: 0.000000
+      9983.T:
+        name: FAST RETAILING CO., LTD.
+        weight: 0.000000
+      9984.T:
+        name: SOFTBANK GROUP CORP.
+        weight: 0.000000
+universe:
+  count: 70
+  members:
+    -
+      ticker: 1332.T
+      name: Nissui
+    -
+      ticker: 1605.T
+      name: Inpex Corp
+    -
+      ticker: 1925.T
+      name: DAIWA HOUSE INDUSTRY CO., LTD.
+    -
+      ticker: 2802.T
+      name: AJINOMOTO CO., INC.
+    -
+      ticker: 2914.T
+      name: JAPAN TOBACCO INC.
+    -
+      ticker: 3382.T
+      name: SEVEN & I HOLDINGS CO., LTD.
+    -
+      ticker: 4061.T
+      name: Denka
+    -
+      ticker: 4063.T
+      name: Shin-Etsu Chemical
+    -
+      ticker: 4151.T
+      name: KYOWA KIRIN CO., LTD.
+    -
+      ticker: 4502.T
+      name: TAKEDA PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4503.T
+      name: ASTELLAS PHARMA INC.
+    -
+      ticker: 4506.T
+      name: SUMITOMO PHARMA CO., LTD.
+    -
+      ticker: 4507.T
+      name: SHIONOGI & CO., LTD.
+    -
+      ticker: 4519.T
+      name: CHUGAI PHARMACEUTICAL CO., LTD.
+    -
+      ticker: 4523.T
+      name: EISAI CO., LTD.
+    -
+      ticker: 4568.T
+      name: DAIICHI SANKYO CO., LTD.
+    -
+      ticker: 4661.T
+      name: ORIENTAL LAND CO., LTD.
+    -
+      ticker: 5714.T
+      name: DOWA Holdings
+    -
+      ticker: 5802.T
+      name: SUMITOMO ELECTRIC INDUSTRIES, LTD.
+    -
+      ticker: 5803.T
+      name: FUJIKURA LTD.
+    -
+      ticker: 6301.T
+      name: KOMATSU LTD.
+    -
+      ticker: 6367.T
+      name: DAIKIN INDUSTRIES,LTD.
+    -
+      ticker: 6479.T
+      name: MINEBEA MITSUMI INC.
+    -
+      ticker: 6501.T
+      name: HITACHI, LTD.
+    -
+      ticker: 6503.T
+      name: MITSUBISHI ELECTRIC CORP.
+    -
+      ticker: 6504.T
+      name: FUJI ELECTRIC CO., LTD.
+    -
+      ticker: 6506.T
+      name: YASKAWA ELECTRIC CORP.
+    -
+      ticker: 6594.T
+      name: NIDEC CORP.
+    -
+      ticker: 6645.T
+      name: OMRON CORP.
+    -
+      ticker: 6674.T
+      name: GS YUASA CORP.
+    -
+      ticker: 6701.T
+      name: NEC CORP.
+    -
+      ticker: 6702.T
+      name: FUJITSU LTD.
+    -
+      ticker: 6723.T
+      name: RENESAS ELECTRONICS CORP.
+    -
+      ticker: 6724.T
+      name: SEIKO EPSON CORP.
+    -
+      ticker: 6752.T
+      name: PANASONIC HOLDINGS CORP.
+    -
+      ticker: 6753.T
+      name: SHARP CORP.
+    -
+      ticker: 6758.T
+      name: SONY GROUP CORP.
+    -
+      ticker: 6762.T
+      name: TDK CORP.
+    -
+      ticker: 6770.T
+      name: ALPS ALPINE CO., LTD.
+    -
+      ticker: 6841.T
+      name: YOKOGAWA ELECTRIC CORP.
+    -
+      ticker: 6857.T
+      name: ADVANTEST CORP.
+    -
+      ticker: 6861.T
+      name: KEYENCE CORP.
+    -
+      ticker: 6902.T
+      name: DENSO CORP.
+    -
+      ticker: 6952.T
+      name: CASIO COMPUTER CO., LTD.
+    -
+      ticker: 6954.T
+      name: FANUC CORP.
+    -
+      ticker: 6963.T
+      name: ROHM CO., LTD.
+    -
+      ticker: 6981.T
+      name: MURATA MANUFACTURING CO., LTD.
+    -
+      ticker: 7011.T
+      name: Mitsubishi Heavy Industries
+    -
+      ticker: 7012.T
+      name: Kawasaki Heavy Industries
+    -
+      ticker: 7267.T
+      name: HONDA MOTOR CO., LTD.
+    -
+      ticker: 7751.T
+      name: CANON INC.
+    -
+      ticker: 7832.T
+      name: BANDAI NAMCO HOLDINGS INC.
+    -
+      ticker: 7974.T
+      name: NINTENDO CO., LTD.
+    -
+      ticker: 8031.T
+      name: MITSUI & CO., LTD.
+    -
+      ticker: 8267.T
+      name: AEON CO., LTD.
+    -
+      ticker: 8306.T
+      name: MITSUBISHI UFJ FINANCIAL GROUP, INC.
+    -
+      ticker: 8308.T
+      name: RESONA HOLDINGS, INC.
+    -
+      ticker: 8309.T
+      name: SUMITOMO MITSUI TRUST GROUP, INC.
+    -
+      ticker: 8316.T
+      name: SUMITOMO MITSUI FINANCIAL GROUP, INC.
+    -
+      ticker: 8411.T
+      name: MIZUHO FINANCIAL GROUP, INC.
+    -
+      ticker: 8604.T
+      name: NOMURA HOLDINGS, INC.
+    -
+      ticker: 8725.T
+      name: MS&AD INSURANCE GROUP HOLDINGS, INC.
+    -
+      ticker: 8766.T
+      name: TOKIO MARINE HOLDINGS, INC.
+    -
+      ticker: 8801.T
+      name: MITSUI FUDOSAN CO., LTD.
+    -
+      ticker: 8802.T
+      name: MITSUBISHI ESTATE CO., LTD.
+    -
+      ticker: 8830.T
+      name: SUMITOMO REALTY & DEVELOPMENT CO., LTD.
+    -
+      ticker: 9432.T
+      name: NTT, INC.
+    -
+      ticker: 9613.T
+      name: NOMURA RESEARCH INSTITUTE, LTD.
+    -
+      ticker: 9983.T
+      name: FAST RETAILING CO., LTD.
+    -
+      ticker: 9984.T
+      name: SOFTBANK GROUP CORP.

--- a/src/reporting/yaml_reporter.py
+++ b/src/reporting/yaml_reporter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .markdown_reporter import render_summary_report
 
 
@@ -42,31 +44,161 @@ def _yaml_lines(data, indent=0):
     return [f"{prefix}{_scalar(data)}"]
 
 
+def _sort_universe(universe):
+    return sorted(
+        (
+            {
+                "ticker": item.get("ticker", ""),
+                "name": item.get("name", ""),
+            }
+            for item in universe
+        ),
+        key=lambda item: item["ticker"],
+    )
+
+
+def _weight_entries(weights):
+    return [
+        {
+            "ticker": ticker,
+            "name": data.get("name", ""),
+            "weight": float(data.get("weight", 0.0)),
+        }
+        for ticker, data in weights.items()
+    ]
+
+
+def _weights_by_ticker(entries):
+    return {
+        entry["ticker"]: {"name": entry["name"], "weight": entry["weight"]}
+        for entry in sorted(entries, key=lambda item: item["ticker"])
+    }
+
+
+def _top_holdings(entries, limit=10):
+    ranked = sorted(entries, key=lambda item: item["weight"], reverse=True)
+    return [
+        {
+            "rank": position,
+            "ticker": entry["ticker"],
+            "name": entry["name"],
+            "weight": entry["weight"],
+        }
+        for position, entry in enumerate(ranked[:limit], start=1)
+    ]
+
+
+def _tail_holdings(entries, limit=5):
+    active = [entry for entry in entries if entry["weight"] > 0]
+    ranked = sorted(active, key=lambda item: item["weight"])
+    return [
+        {
+            "ticker": entry["ticker"],
+            "name": entry["name"],
+            "weight": entry["weight"],
+        }
+        for entry in ranked[:limit]
+    ]
+
+
+def _weight_buckets(entries):
+    buckets = [
+        ("10%以上", 0.10, None),
+        ("5%-10%", 0.05, 0.10),
+        ("1%-5%", 0.01, 0.05),
+        ("1%未満", 0.0, 0.01),
+    ]
+    ranked = sorted(entries, key=lambda item: item["weight"], reverse=True)
+    results = []
+    for label, lower, upper in buckets:
+        members = [
+            entry
+            for entry in ranked
+            if entry["weight"] >= lower and (upper is None or entry["weight"] < upper)
+        ]
+        results.append(
+            {
+                "label": label,
+                "count": len(members),
+                "weight_share": sum(entry["weight"] for entry in members),
+                "sample": [
+                    {
+                        "ticker": entry["ticker"],
+                        "name": entry["name"],
+                        "weight": entry["weight"],
+                    }
+                    for entry in members[:5]
+                ],
+            }
+        )
+    return results
+
+
+def _allocation_summary(entries):
+    total = len(entries)
+    active = [entry for entry in entries if entry["weight"] > 0]
+    inactive = total - len(active)
+    ranked = sorted(entries, key=lambda item: item["weight"], reverse=True)
+    top3 = sum(entry["weight"] for entry in ranked[:3])
+    top10 = sum(entry["weight"] for entry in ranked[:10])
+    return {
+        "total_constituents": total,
+        "invested_constituents": len(active),
+        "zero_weight_constituents": inactive,
+        "top3_weight": top3,
+        "top10_weight": top10,
+    }
+
+
+def _format_year_report(year, payload):
+    portfolio = payload["portfolio"]
+    weight_entries = _weight_entries(portfolio["weights"])
+    return {
+        "year": year,
+        "period": payload["period"],
+        "conditions": {
+            "training_window": portfolio.get("training_window", {}),
+            "evaluation_window": portfolio.get("evaluation_window", {}),
+        },
+        "portfolio": {
+            "risk_metrics": portfolio.get("risk_metrics", {}),
+            "allocations": {
+                "summary": _allocation_summary(weight_entries),
+                "top_holdings": _top_holdings(weight_entries),
+                "smallest_active_weights": _tail_holdings(weight_entries),
+                "weight_buckets": _weight_buckets(weight_entries),
+                "by_ticker": _weights_by_ticker(weight_entries),
+            },
+        },
+        "universe": {
+            "count": len(payload.get("universe", [])),
+            "members": _sort_universe(payload.get("universe", [])),
+        },
+    }
+
+
 def write_reports(results, directory):
     directory.mkdir(parents=True, exist_ok=True)
-    rounded = {year: _round_numbers(payload) for year, payload in results.items()}
-    for year, payload in rounded.items():
-        (directory / f"{year}.yaml").write_text("\n".join(_yaml_lines(payload)) + "\n", encoding="utf-8")
-    if rounded:
+    formatted = {
+        year: _round_numbers(_format_year_report(year, payload))
+        for year, payload in results.items()
+    }
+    for year, payload in formatted.items():
+        (directory / f"{year}.yaml").write_text(
+            "\n".join(_yaml_lines(payload)) + "\n", encoding="utf-8"
+        )
+    if formatted:
         summary = {
             str(year): payload["portfolio"]["risk_metrics"]
-            for year, payload in rounded.items()
+            for year, payload in formatted.items()
         }
         holdings = {
-            str(year): [
-                {
-                    "ticker": ticker,
-                    "name": weight_data.get("name", ""),
-                    "weight": float(weight_data.get("weight", 0.0)),
-                }
-                for ticker, weight_data in sorted(
-                    payload["portfolio"]["weights"].items(),
-                    key=lambda item: item[1].get("weight", 0.0),
-                    reverse=True,
-                )[:10]
-            ]
-            for year, payload in rounded.items()
+            str(year): payload["portfolio"]["allocations"]["top_holdings"]
+            for year, payload in formatted.items()
         }
-        (directory / "summary.yaml").write_text("\n".join(_yaml_lines({"years": summary})) + "\n", encoding="utf-8")
+        (directory / "summary.yaml").write_text(
+            "\n".join(_yaml_lines({"years": summary})) + "\n",
+            encoding="utf-8",
+        )
         report = render_summary_report(summary, holdings)
         (directory / "summary_report.md").write_text(report, encoding="utf-8")


### PR DESCRIPTION
## Summary
- restructure the YAML reporter to build richer per-year payloads with allocation summaries, rankings, and sorted universes for improved readability
- refresh existing portfolio year YAML artifacts to the new readable layout with conditions, top holdings, and bucketed weight snapshots

## Testing
- python -m compileall src/reporting/yaml_reporter.py

------
https://chatgpt.com/codex/tasks/task_e_68e4cb3fe5908325b2722e0ecf91fb19