### PR TITLE
Refactor visualization panel generation

### DIFF
--- a/src/analytics/visualization.py
+++ b/src/analytics/visualization.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import math
 import os
 import warnings
 
@@ -9,7 +8,6 @@ from matplotlib.axes import Axes
 import pandas as pd
 import yaml
 import yfinance as yf
-import numpy as np
 
 from ..common.config import DATA_RAW, REPORT_DIR, TICKER_NAMES_FILE, ABENOMICS_START, ABENOMICS_END, TIMELINE_START
 from ..data_io.yaml_store import load_frames
@@ -123,15 +121,15 @@ def _plot_no_data_message(ax, year, message, global_start, global_end):
     ax.set_yticks([])
     ax.set_title(str(year), fontsize=14, fontweight="bold")
     ax.set_xlim(global_start, global_end)
-    ax.set_ylim(0.1, 10) # Changed ylim
-    ax.set_yscale('log')
+    ax.set_ylim(0.1, 10)
+    ax.set_yscale("log")
 
 def create_yearly_portfolio_panels(output_path: Path) -> Path:
     ticker_names = _load_ticker_names()
     portfolios = _load_portfolios(ticker_names)
     if not portfolios:
         fig, ax = plt.subplots(figsize=(6, 4))
-        _plot_no_data_message(ax, "", "No portfolio data available", None, None) # No year for overall message
+        _plot_no_data_message(ax, "", "No portfolio data available", None, None)
         ax.axis("off")
         output_path.parent.mkdir(parents=True, exist_ok=True)
         fig.tight_layout()
@@ -142,34 +140,38 @@ def create_yearly_portfolio_panels(output_path: Path) -> Path:
     years_with_data = sorted(portfolios)
     full_year_range = list(range(min(years_with_data), max(years_with_data) + 1))
     tickers = sorted({holding["ticker"] for info in portfolios.values() for holding in info["holdings"]})
-    global_start = pd.Timestamp(TIMELINE_START).tz_localize(None) # Changed global_start
-    global_end = pd.Timestamp.now().normalize() # Extend to today
+    global_start = pd.Timestamp(TIMELINE_START).tz_localize(None)
+    global_end = pd.Timestamp.now().normalize()
     closes = _load_closes(tickers, global_start, global_end) if tickers else pd.DataFrame()
 
-    cols = 1
-    rows = len(full_year_range)
-    fig, axes = plt.subplots(rows, cols, figsize=(cols * 24, rows * 5)) # Doubled width
+    fig, axes = plt.subplots(len(full_year_range), 1, figsize=(24, 5 * len(full_year_range)))
     axes = [axes] if isinstance(axes, Axes) else list(axes.ravel())
 
-    cmap = plt.get_cmap("tab20") # Changed colormap to tab20
-    colors = {ticker: cmap(i % cmap.N) for i, ticker in enumerate(tickers)} # Use modulo for tab20
+    cmap = plt.get_cmap("tab20")
+    colors = {ticker: cmap(i % cmap.N) for i, ticker in enumerate(tickers)}
 
-    # Convert Abenomics dates to Timestamp objects
     abenomics_start_ts = pd.Timestamp(ABENOMICS_START).tz_localize(None)
     abenomics_end_ts = pd.Timestamp(ABENOMICS_END).tz_localize(None)
+
+    def _finalize_axis(ax: Axes, index: int):
+        if index < len(full_year_range) - 1:
+            ax.set_xlabel("")
+            ax.tick_params(labelbottom=False)
+        else:
+            ax.set_xlabel("Date", fontsize=10)
+
+    def _no_data(ax: Axes, index: int, year, message):
+        _plot_no_data_message(ax, year, message, global_start, global_end)
+        _finalize_axis(ax, index)
 
     for i, (ax, year) in enumerate(zip(axes, full_year_range)):
         ax.set_facecolor("#f9f9f9")
         ax.set_xlim(global_start, global_end)
-        ax.set_ylim(0.1, 10) # Changed ylim
-        ax.set_yscale('log')
+        ax.set_ylim(0.1, 10)
+        ax.set_yscale("log")
 
         if year not in portfolios:
-            _plot_no_data_message(ax, year, f"No data for {year}", global_start, global_end)
-            # Hide x-axis labels for non-last subplots
-            if i < len(full_year_range) - 1:
-                ax.set_xlabel('')
-                ax.tick_params(labelbottom=False)
+            _no_data(ax, i, year, f"No data for {year}")
             continue
 
         info = portfolios[year]
@@ -177,133 +179,74 @@ def create_yearly_portfolio_panels(output_path: Path) -> Path:
         available_tickers = [ticker for ticker in weights.index if not closes.empty and ticker in closes.columns]
 
         if not available_tickers:
-            _plot_no_data_message(ax, year, "No local price data", global_start, global_end)
-            # Hide x-axis labels for non-last subplots
-            if i < len(full_year_range) - 1:
-                ax.set_xlabel('')
-                ax.tick_params(labelbottom=False)
+            _no_data(ax, i, year, "No local price data")
             continue
 
         weights = weights.loc[available_tickers]
-        weights = weights / weights.sum()
-        subset = closes.loc[:, available_tickers]
+        subset = closes[available_tickers]
+        series_map = {ticker: series.dropna() for ticker, series in subset.items()}
+        series_map = {ticker: series for ticker, series in series_map.items() if not series.empty}
 
-        valid_columns = []
-        start_dates = []
-        for ticker, series in subset.items():
-            cleaned = series.dropna()
-            if cleaned.empty:
-                continue
-            valid_columns.append(ticker)
-            start_dates.append(cleaned.index.min())
-
-        if not valid_columns:
-            _plot_no_data_message(ax, year, "Insufficient price history", global_start, global_end)
-            # Hide x-axis labels for non-last subplots
-            if i < len(full_year_range) - 1:
-                ax.set_xlabel('')
-                ax.tick_params(labelbottom=False)
+        if not series_map:
+            _no_data(ax, i, year, "Insufficient price history")
             continue
 
-        subset = subset.loc[:, valid_columns]
-        start = max(start_dates + [info["start"]])
-        subset = subset.loc[subset.index >= start]
-        subset = subset.ffill()
+        start = max([info["start"], *(series.index.min() for series in series_map.values())])
+        frame = pd.DataFrame(series_map).loc[lambda df: df.index >= start].ffill()
 
-        if subset.empty:
-            _plot_no_data_message(ax, year, "No prices after start date", global_start, global_end)
-            # Hide x-axis labels for non-last subplots
-            if i < len(full_year_range) - 1:
-                ax.set_xlabel('')
-                ax.tick_params(labelbottom=False)
+        if frame.empty:
+            _no_data(ax, i, year, "No prices after start date")
             continue
 
-        base = subset.iloc[0]
-        normalized = subset.divide(base)
-        scaled = normalized * 1 # Changed base from 100 to 1
+        weights = (weights.loc[frame.columns] / weights.loc[frame.columns].sum()).astype(float)
+        scaled = frame.divide(frame.iloc[0])
         portfolio_curve = scaled.mul(weights, axis=1).sum(axis=1)
 
-        # Plot Abenomics period
-        ax.axvspan(abenomics_start_ts, abenomics_end_ts, color="gray", alpha=0.2, label="Abenomics Period")
+        abenomics_patch = ax.axvspan(abenomics_start_ts, abenomics_end_ts, color="gray", alpha=0.2, label="Abenomics Period")
 
-        lines = []
-        labels = []
-        for ticker in scaled.columns:
-            name = ticker_names.get(ticker, ticker)
-            line, = ax.plot(
+        lines = [
+            ax.plot(
                 scaled.index,
                 scaled[ticker],
                 linewidth=1.5,
                 alpha=0.8,
                 color=colors.get(ticker, "#555555"),
-                label=f"{name} ({weights[ticker]:.1%})",
-            )
-            lines.append(line)
-            labels.append(f"{name} ({weights[ticker]:.1%})")
+                label=f"{ticker_names.get(ticker, ticker)} ({weights[ticker]:.1%})",
+            )[0]
+            for ticker in scaled.columns
+        ]
 
-        portfolio_line, = ax.plot(
+        portfolio_line = ax.plot(
             portfolio_curve.index,
             portfolio_curve,
             linewidth=2.5,
             color="black",
             label="Portfolio",
+        )[0]
+
+        legend_entries = sorted(
+            [(portfolio_curve.iloc[-1] if not portfolio_curve.empty else float("-inf"), portfolio_line, "Portfolio")]
+            + [(scaled[ticker].iloc[-1], line, line.get_label()) for ticker, line in zip(scaled.columns, lines)],
+            key=lambda item: item[0],
+            reverse=True,
         )
-        lines.append(portfolio_line)
-        labels.append("Portfolio")
 
-        # Sort legend entries by final indexed performance
-        final_values = []
-        for line in lines:
-            if line.get_label() == "Portfolio":
-                final_values.append(portfolio_curve.iloc[-1] if not portfolio_curve.empty else -np.inf)
-            elif line.get_label() == "Abenomics Period": # Skip Abenomics Period from sorting
-                final_values.append(-np.inf) # Place it at the bottom
-            else:
-                ticker_label = line.get_label().split(' ')[0] # Extract ticker from label
-                if ticker_label in scaled.columns and not scaled[ticker_label].empty:
-                    final_values.append(scaled[ticker_label].iloc[-1])
-                else:
-                    final_values.append(-np.inf) # Handle cases where data might be missing
-
-        # Filter out Abenomics Period from sorting and re-add it later
-        sorted_items = sorted([(val, line, label) for val, line, label in zip(final_values, lines, labels) if label != "Abenomics Period"], key=lambda item: item[0], reverse=True)
-        sorted_lines = [item[1] for item in sorted_items]
-        sorted_labels = [item[2] for item in sorted_items]
-
-        # Add Abenomics Period back if it was present
-        abenomics_handle = None
-        abenomics_label = None
-        for line, label in zip(lines, labels):
-            if label == "Abenomics Period":
-                abenomics_handle = line
-                abenomics_label = label
-                break
-        if abenomics_handle and abenomics_label:
-            sorted_lines.append(abenomics_handle)
-            sorted_labels.append(abenomics_label)
+        handles = [entry[1] for entry in legend_entries] + [abenomics_patch]
+        labels = [entry[2] for entry in legend_entries] + ["Abenomics Period"]
 
         ax.set_title(str(year), fontsize=14, fontweight="bold")
-        ax.set_ylabel("Indexed performance (base = 1)", fontsize=10) # Changed base from 100 to 1
-        ax.grid(True, which="both", ls="-", alpha=0.5) # Ensure both major and minor grid lines
-        ax.xaxis.set_major_locator(mdates.YearLocator()) # Changed to YearLocator
-        ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y")) # Changed to display year only
+        ax.set_ylabel("Indexed performance (base = 1)", fontsize=10)
+        ax.grid(True, which="both", ls="-", alpha=0.5)
+        ax.xaxis.set_major_locator(mdates.YearLocator())
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y"))
         ax.tick_params(axis="x", rotation=30, labelsize=9)
         ax.tick_params(axis="y", labelsize=9)
-        ax.legend(sorted_lines, sorted_labels, fontsize=10, ncol=1, frameon=True, loc='center left', bbox_to_anchor=(1, 0.5), facecolor="white", framealpha=1.0)
+        ax.legend(handles, labels, fontsize=10, ncol=1, frameon=True, loc="center left", bbox_to_anchor=(1, 0.5), facecolor="white", framealpha=1.0)
 
-        # Hide x-axis labels for non-last subplots
-        if i < len(full_year_range) - 1:
-            ax.set_xlabel('')
-            ax.tick_params(labelbottom=False)
-        else:
-            ax.set_xlabel("Date", fontsize=10)
-
-
-    for ax in axes[len(full_year_range):]:
-        fig.delaxes(ax)
+        _finalize_axis(ax, i)
 
     fig.suptitle("Portfolio Performance by Year", fontsize=18, fontweight="bold")
-    fig.tight_layout(rect=(0, 0, 0.92, 0.96)) # Adjusted rect for wider graph
+    fig.tight_layout(rect=(0, 0, 0.92, 0.96))
     output_path.parent.mkdir(parents=True, exist_ok=True)
     fig.savefig(output_path, format=output_path.suffix.lstrip("."), dpi=150)
     plt.close(fig)


### PR DESCRIPTION
## Summary
- streamline yearly portfolio panel plotting to reduce duplicated axis handling and legend logic
- simplify data preparation, weighting, and colormap usage for yearly portfolio charts
- drop unused imports and clean no-data message handling

## Testing
- python -m compileall src/analytics/visualization.py

------
https://chatgpt.com/codex/tasks/task_e_68e4e79118588325a2592960db8f939b