### PR TITLE
Remove Python comments and defensive error handling

### DIFF
--- a/src/reporting/markdown_reporter.py
+++ b/src/reporting/markdown_reporter.py
@@ -29,9 +29,6 @@ def render_summary_report(
     top_holdings: Optional[Mapping[str, Sequence[Mapping[str, float]]]] = None,
 ) -> str:
     rows = _prepare_rows(summary)
-    if not rows:
-        return "# ポートフォリオ年次パフォーマンス概要\n\nデータがありません。\n"
-
     best_return = max(rows, key=lambda row: row["annual_return"])
     worst_return = min(rows, key=lambda row: row["annual_return"])
     lowest_volatility = min(rows, key=lambda row: row["volatility"])
@@ -119,11 +116,7 @@ def render_summary_report(
                 ticker = holding.get("ticker", "")
                 name = holding.get("name") or ticker
                 weight = float(holding.get("weight", float("nan")))
-                rank = holding.get("rank", default_rank)
-                try:
-                    rank = int(rank)
-                except (TypeError, ValueError):
-                    rank = default_rank
+                rank = int(holding.get("rank", default_rank))
                 lines.append(
                     f"- {rank}. {name}（{ticker}）: {_percent(weight)}"
                 )


### PR DESCRIPTION
## Summary
- strip docstrings and defensive guards from the universe utilities while keeping core data flows intact
- simplify the visualization data loaders by removing warning-based handling and assuming successful downloads
- streamline markdown report rendering by relying on direct rank conversion without exception handling

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e4f38e0bc0832597afcf8bf1033ecb