### PR TITLE
Remove redundant defensive branches

### DIFF
--- a/src/reporting/markdown_reporter.py
+++ b/src/reporting/markdown_reporter.py
@@ -102,26 +102,19 @@ def render_summary_report(
         ]
     )
 
-    years = (
-        sorted(holdings_by_year, key=int)
-        if holdings_by_year
-        else [str(latest_year["year"])]
-    )
+    years = sorted(holdings_by_year, key=int)
 
     for year in years:
         holdings = list(holdings_by_year.get(year, []))
         lines.extend([f"## {year}年ポートフォリオ上位10銘柄", ""])
-        if holdings:
-            for default_rank, holding in enumerate(holdings[:10], start=1):
-                ticker = holding.get("ticker", "")
-                name = holding.get("name") or ticker
-                weight = float(holding.get("weight", float("nan")))
-                rank = int(holding.get("rank", default_rank))
-                lines.append(
-                    f"- {rank}. {name}（{ticker}）: {_percent(weight)}"
-                )
-        else:
-            lines.append("- データが不足しています。")
+        for default_rank, holding in enumerate(holdings[:10], start=1):
+            ticker = holding.get("ticker", "")
+            name = holding.get("name") or ticker
+            weight = float(holding.get("weight", float("nan")))
+            rank = int(holding.get("rank", default_rank))
+            lines.append(
+                f"- {rank}. {name}（{ticker}）: {_percent(weight)}"
+            )
         lines.append("")
 
     return "\n".join(lines)

--- a/src/reporting/yaml_reporter.py
+++ b/src/reporting/yaml_reporter.py
@@ -163,18 +163,17 @@ def write_reports(results, directory):
         (directory / f"{year}.yaml").write_text(
             "\n".join(_yaml_lines(payload)) + "\n", encoding="utf-8"
         )
-    if formatted:
-        summary = {
-            str(year): payload["portfolio"]["risk_metrics"]
-            for year, payload in formatted.items()
-        }
-        holdings = {
-            str(year): payload["portfolio"]["allocations"]["top_holdings"]
-            for year, payload in formatted.items()
-        }
-        (directory / "summary.yaml").write_text(
-            "\n".join(_yaml_lines({"years": summary})) + "\n",
-            encoding="utf-8",
-        )
-        report = render_summary_report(summary, holdings)
-        (directory / "summary_report.md").write_text(report, encoding="utf-8")
+    summary = {
+        str(year): payload["portfolio"]["risk_metrics"]
+        for year, payload in formatted.items()
+    }
+    holdings = {
+        str(year): payload["portfolio"]["allocations"]["top_holdings"]
+        for year, payload in formatted.items()
+    }
+    (directory / "summary.yaml").write_text(
+        "\n".join(_yaml_lines({"years": summary})) + "\n",
+        encoding="utf-8",
+    )
+    report = render_summary_report(summary, holdings)
+    (directory / "summary_report.md").write_text(report, encoding="utf-8")


### PR DESCRIPTION
## Summary
- drop optional fallbacks in the visualization data loaders so they assume complete report content
- simplify the summary report generation by eliminating conditional guards that handled missing data

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e4f790e2ac8325b1ad59ceca218e74